### PR TITLE
Release 2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.10] - 2026-01-01
+
+### Changed
+- **Pragmatica Lite Core** updated from 0.9.0 to 0.9.3
+  - 0.9.1: Dependency updates, deprecation warning fixes
+  - 0.9.2: KSUID (replaces ULID), JOOQ integration module
+  - 0.9.3: Consensus module (CFT protocol)
+  - Core API unchanged - version bump only
+- **Fixed deprecated `Verify.ensure()` syntax** across documentation
+  - Old: `Verify.ensure(CAUSE, value, predicate)` (deprecated, forRemoval)
+  - New: `Verify.ensure(value, predicate, CAUSE)` (cause-at-end)
+  - Updated: articles/value-objects-cookbook.md, articles/parse-dont-validate.md, CODING_GUIDE.md, README.md
+- **jbct-cli 0.4.3 improvements** (parser and formatter fixes)
+  - Farthest failure tracking for better error positions
+  - Multiple formatter alignment fixes
+  - JBCT-SEAL-01 and JBCT-PAT-02 false positive fixes
+
 ## [2.0.9] - 2025-12-27
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,22 +201,22 @@ When writing Java code examples, follow these formatting conventions strictly:
 
 ---
 
-# Pragmatica Lite Core 0.9.0 API Reference
+# Pragmatica Lite Core 0.9.3 API Reference
 
-This section documents the actual API methods available in Pragmatica Lite Core 0.9.0.
+This section documents the actual API methods available in Pragmatica Lite Core 0.9.3.
 
 **Maven:**
 ```xml
 <dependency>
    <groupId>org.pragmatica-lite</groupId>
    <artifactId>core</artifactId>
-   <version>0.9.0</version>
+   <version>0.9.3</version>
 </dependency>
 ```
 
 **Gradle:**
 ```gradle
-implementation 'org.pragmatica-lite:core:0.9.0'
+implementation 'org.pragmatica-lite:core:0.9.3'
 ```
 
 Library documentation: https://central.sonatype.com/artifact/org.pragmatica-lite/core

--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -582,13 +582,13 @@ public class UserController {
 > <dependency>
 >    <groupId>org.pragmatica-lite</groupId>
 >    <artifactId>core</artifactId>
->    <version>0.9.0</version>
+>    <version>0.9.3</version>
 > </dependency>
 > ```
 >
 > **Gradle:**
 > ```gradle
-> implementation 'org.pragmatica-lite:core:0.9.0'
+> implementation 'org.pragmatica-lite:core:0.9.3'
 > ```
 
 ### The Four Return Kinds
@@ -939,9 +939,9 @@ public record DateRange(LocalDate start, LocalDate end) {
     private static final Fn1<Cause, LocalDate> END_BEFORE_START = Causes.forOneValue("End date must be after start date: %s");
 
     public static Result<DateRange> dateRange(LocalDate start, LocalDate end) {
-        return Verify.ensure(START_REQUIRED, start, Verify.Is::notNull)
-                     .flatMap(_ -> Verify.ensure(END_REQUIRED, end, Verify.Is::notNull))
-                     .flatMap(_ -> Verify.ensure(END_BEFORE_START, end, isAfter(start)))
+        return Verify.ensure(start, Verify.Is::notNull, START_REQUIRED)
+                     .flatMap(_ -> Verify.ensure(end, Verify.Is::notNull, END_REQUIRED))
+                     .flatMap(_ -> Verify.ensure(end, isAfter(start), END_BEFORE_START))
                      .map(_ -> new DateRange(start, end));
     }
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ public record Email(String value) {
     private static final Fn1<Cause, String> INVALID_FORMAT = Causes.forOneValue("Invalid email format: %s");
 
     public static Result<Email> email(String raw) {
-        return Verify.ensure(EMAIL_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, EMAIL_REQUIRED)
             .filter(EMAIL_BLANK, Verify.Is::notBlank)
             .filter(INVALID_FORMAT, PATTERN.asMatchPredicate())
             .map(Email::new);
@@ -231,8 +231,8 @@ void email_acceptsValidFormat() {
 ### Changelog & Versioning
 
 - **[CHANGELOG.md](CHANGELOG.md)** - Version history following [Keep a Changelog](https://keepachangelog.com/)
-  - Current version: 2.0.9 (2025-12-27)
-  - Golden formatting patterns, Pragmatica Lite 0.9.0, 36 lint rules
+  - Current version: 2.0.10 (2026-01-01)
+  - Golden formatting patterns, Pragmatica Lite 0.9.3, 36 lint rules
   - Semantic versioning for documentation releases
 
 ## 🔧 Tools
@@ -359,13 +359,13 @@ This repository documents a methodology, not a software project. Contributions w
 <dependency>
    <groupId>org.pragmatica-lite</groupId>
    <artifactId>core</artifactId>
-   <version>0.9.0</version>
+   <version>0.9.3</version>
 </dependency>
 ```
 
 **Gradle:**
 ```gradle
-implementation 'org.pragmatica-lite:core:0.9.0'
+implementation 'org.pragmatica-lite:core:0.9.3'
 ```
 
 ## 📄 License

--- a/articles/parse-dont-validate.md
+++ b/articles/parse-dont-validate.md
@@ -87,7 +87,7 @@ public record Email(String value) {
 
     // Factory method: the ONLY way to create an Email
     public static Result<Email> email(String raw) {
-        return Verify.ensure(EMAIL_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, EMAIL_REQUIRED)
             .map(String::trim)
             .map(String::toLowerCase)
             .filter(INVALID_FORMAT, PATTERN.asMatchPredicate())
@@ -173,7 +173,7 @@ public record DateRange(LocalDate start, LocalDate end) {
         Causes.cause("End date must be after start date");
 
     public static Result<DateRange> dateRange(LocalDate start, LocalDate end) {
-        return Verify.ensure(END_BEFORE_START, end, e -> !e.isBefore(start))
+        return Verify.ensure(end, e -> !e.isBefore(start), END_BEFORE_START)
             .map(_ -> new DateRange(start, end));
     }
 }
@@ -216,7 +216,7 @@ Factories can also normalize data:
 
 ```java
 public static Result<Email> email(String raw) {
-    return Verify.ensure(EMAIL_REQUIRED, raw, Verify.Is::notNull)
+    return Verify.ensure(raw, Verify.Is::notNull, EMAIL_REQUIRED)
         .map(String::trim)           // Remove whitespace
         .map(String::toLowerCase)    // Normalize case
         .filter(INVALID_FORMAT, PATTERN.asMatchPredicate())

--- a/articles/value-objects-cookbook.md
+++ b/articles/value-objects-cookbook.md
@@ -44,7 +44,7 @@ public record Email(String value) {
         Causes.forOneValue("Invalid email format: %s");
 
     public static Result<Email> email(String raw) {
-        return Verify.ensure(EMAIL_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, EMAIL_REQUIRED)
             .filter(INVALID_FORMAT, PATTERN.asMatchPredicate())
             .map(Email::new);
     }
@@ -80,7 +80,7 @@ public record Email(String value) {
         Causes.forOneValue("Invalid email format: %s");
 
     public static Result<Email> email(String raw) {
-        return Verify.ensure(EMAIL_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, EMAIL_REQUIRED)
             .map(String::trim)           // Remove whitespace
             .map(String::toLowerCase)    // Normalize case
             .filter(INVALID_FORMAT, PATTERN.asMatchPredicate())
@@ -110,14 +110,14 @@ public record Age(int value) {
         Causes.cause("Age must be between 0 and 150");
 
     public static Result<Age> age(String raw) {
-        return Verify.ensure(AGE_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, AGE_REQUIRED)
             .flatMap(Number::parseInt)  // Uses parse utility
             .filter(AGE_OUT_OF_RANGE, v -> Verify.Is.between(v, 0, 150))
             .map(Age::new);
     }
 
     public static Result<Age> age(int value) {
-        return Verify.ensure(AGE_OUT_OF_RANGE, value, Verify.Is::between, 0, 150)
+        return Verify.ensure(value, Verify.Is::between, 0, 150, AGE_OUT_OF_RANGE)
             .map(Age::new);
     }
 }
@@ -147,7 +147,7 @@ public record Username(String value) {
         Causes.cause("Username can only contain letters, numbers, underscores, and hyphens");
 
     public static Result<Username> username(String raw) {
-        return Verify.ensure(USERNAME_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, USERNAME_REQUIRED)
             .map(String::trim)
             .filter(USERNAME_TOO_SHORT, s -> s.length() >= MIN_LENGTH)
             .filter(USERNAME_TOO_LONG, s -> s.length() <= MAX_LENGTH)
@@ -182,7 +182,7 @@ public record Password(String value) {
         Causes.cause("Password must contain a digit");
 
     public static Result<Password> password(String raw) {
-        return Verify.ensure(PASSWORD_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, PASSWORD_REQUIRED)
             .filter(TOO_SHORT, s -> s.length() >= MIN_LENGTH)
             .filter(TOO_LONG, s -> s.length() <= MAX_LENGTH)
             .filter(MISSING_UPPERCASE, s -> s.chars().anyMatch(Character::isUpperCase))
@@ -214,7 +214,7 @@ public record PhoneNumber(CountryCode countryCode, String localNumber) {
     }
 
     private static Result<String> validateLocalNumber(String raw) {
-        return Verify.ensure(Causes.cause("Local number required"), raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, Causes.cause("Local number required"))
             .map(s -> s.replaceAll("[^0-9]", ""))  // Strip non-digits
             .filter(Causes.cause("Local number must be 7-15 digits"),
                     s -> Verify.Is.lenBetween(s, 7, 15));
@@ -256,8 +256,8 @@ public record DateRange(LocalDate start, LocalDate end) {
 
     public static Result<DateRange> dateRange(LocalDate start, LocalDate end) {
         return Result.all(
-            Verify.ensure(START_REQUIRED, start, Verify.Is::notNull),
-            Verify.ensure(END_REQUIRED, end, Verify.Is::notNull)
+            Verify.ensure(start, Verify.Is::notNull, START_REQUIRED),
+            Verify.ensure(end, Verify.Is::notNull, END_REQUIRED)
         ).flatMap((s, e) -> validateRange(s, e));
     }
 
@@ -339,7 +339,7 @@ public record Currency(String code) {
         Causes.forOneValue("Unsupported currency: %s");
 
     public static Result<Currency> currency(String raw) {
-        return Verify.ensure(CURRENCY_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, CURRENCY_REQUIRED)
             .map(String::trim)
             .map(String::toUpperCase)
             .filter(UNSUPPORTED, VALID_CODES::contains)
@@ -367,7 +367,7 @@ public record UserId(String value) {
         Causes.cause("User ID must be a valid UUID");
 
     public static Result<UserId> userId(String raw) {
-        return Verify.ensure(USER_ID_REQUIRED, raw, Verify.Is::notNull)
+        return Verify.ensure(raw, Verify.Is::notNull, USER_ID_REQUIRED)
             .map(String::trim)
             .flatMap(s -> Network.parseUUID(s)  // Validates UUID format
                 .mapError(_ -> USER_ID_INVALID))

--- a/jbct-coder.md
+++ b/jbct-coder.md
@@ -1,7 +1,7 @@
 ---
 name: jbct-coder
 title: Java Backend Coding Technology Agent
-description: Specialized agent for generating business logic code using Java Backend Coding Technology v2.0.9 with Pragmatica Lite Core 0.9.0. Produces deterministic, AI-friendly code that matches human-written code structurally and stylistically. Includes evolutionary testing strategy guidance.
+description: Specialized agent for generating business logic code using Java Backend Coding Technology v2.0.10 with Pragmatica Lite Core 0.9.3. Produces deterministic, AI-friendly code that matches human-written code structurally and stylistically. Includes evolutionary testing strategy guidance.
 tools: Read, Write, Edit, MultiEdit, Grep, Glob, LS, Bash, TodoWrite, Task, WebSearch, WebFetch
 ---
 
@@ -59,9 +59,9 @@ You are a Java Backend Coding Technology developer with deep knowledge of Java, 
 
 ## Purpose
 
-This guide provides **deterministic instructions** for generating business logic code using Pragmatica Lite Core 0.9.0. Follow these rules precisely to ensure AI-generated code matches human-written code structurally and stylistically.
+This guide provides **deterministic instructions** for generating business logic code using Pragmatica Lite Core 0.9.3. Follow these rules precisely to ensure AI-generated code matches human-written code structurally and stylistically.
 
-**Pragmatica Lite Core 0.9.0:**
+**Pragmatica Lite Core 0.9.3:**
 
 **IMPORTANT: Always use Maven unless the user explicitly requests Gradle.**
 
@@ -70,13 +70,13 @@ This guide provides **deterministic instructions** for generating business logic
 <dependency>
    <groupId>org.pragmatica-lite</groupId>
    <artifactId>core</artifactId>
-   <version>0.9.0</version>
+   <version>0.9.3</version>
 </dependency>
 ```
 
 **Gradle (only if explicitly requested):**
 ```gradle
-implementation 'org.pragmatica-lite:core:0.9.0'
+implementation 'org.pragmatica-lite:core:0.9.3'
 ```
 
 Library documentation: https://central.sonatype.com/artifact/org.pragmatica-lite/core
@@ -1713,7 +1713,7 @@ public class JooqUserRepository implements SaveUser {
 
 ## References
 
-- **Full Guide**: `CODING_GUIDE.md` - Comprehensive explanation of all patterns and principles (v2.0.9)
+- **Full Guide**: `CODING_GUIDE.md` - Comprehensive explanation of all patterns and principles (v2.0.10)
 - **Testing Strategy**: `series/part-05-testing-strategy.md` - Evolutionary testing approach, integration-first philosophy, test organization
 - **Systematic Application**: `series/part-10-systematic-application.md` - Checkpoints for coding and review
 - **API Reference**: `CLAUDE.md` - Complete Pragmatica Lite API documentation

--- a/jbct-reviewer.md
+++ b/jbct-reviewer.md
@@ -13,27 +13,27 @@ Your goal is to provide comprehensive, actionable code review focused on JBCT co
 
 ## Pragmatica Lite Core Library
 
-JBCT uses **Pragmatica Lite Core 0.9.0** for functional types (`Option`, `Result`, `Promise`).
+JBCT uses **Pragmatica Lite Core 0.9.3** for functional types (`Option`, `Result`, `Promise`).
 
 **Correct Maven dependency:**
 ```xml
 <dependency>
    <groupId>org.pragmatica-lite</groupId>
    <artifactId>core</artifactId>
-   <version>0.9.0</version>
+   <version>0.9.3</version>
 </dependency>
 ```
 
 **Correct Gradle dependency (only if Maven not used):**
 ```gradle
-implementation 'org.pragmatica-lite:core:0.9.0'
+implementation 'org.pragmatica-lite:core:0.9.3'
 ```
 
 **Check for:**
 - ❌ Incorrect groupId (e.g., `org.pragmatica`, `com.pragmatica-lite`)
 - ❌ Incorrect artifactId (e.g., `pragmatica-core`, `pragmatica-lite`)
-- ❌ Outdated version (e.g., `0.7.x`, `0.8.0`, `0.8.1`, `0.8.2`, `0.8.3`)
-- ✅ Correct: `org.pragmatica-lite:core:0.9.0`
+- ❌ Outdated version (e.g., `0.7.x`, `0.8.x`, `0.9.0`, `0.9.1`, `0.9.2`)
+- ✅ Correct: `org.pragmatica-lite:core:0.9.3`
 
 Library documentation: https://central.sonatype.com/artifact/org.pragmatica-lite/core
 
@@ -1347,8 +1347,8 @@ Before reviewing, enumerate ALL files to review:
 **Check dependency declaration** in `pom.xml` or `build.gradle`:
 - [ ] Correct groupId: `org.pragmatica-lite` (not `org.pragmatica`, `com.pragmatica-lite`)
 - [ ] Correct artifactId: `core` (not `pragmatica-core`, `pragmatica-lite`)
-- [ ] Correct version: `0.9.0` (not `0.7.x`, `0.8.0`, `0.8.1`, `0.8.2`, `0.8.3`)
-- [ ] Full coordinates: `org.pragmatica-lite:core:0.9.0`
+- [ ] Correct version: `0.9.3` (not `0.7.x`, `0.8.x`, `0.9.0`, `0.9.1`, `0.9.2`)
+- [ ] Full coordinates: `org.pragmatica-lite:core:0.9.3`
 
 **If build file not provided**, note this in review and recommend verification.
 
@@ -1484,14 +1484,14 @@ Structure your review as follows:
 **Example Issues**:
 - ❌ Wrong groupId: `org.pragmatica` → should be `org.pragmatica-lite`
 - ❌ Wrong artifactId: `pragmatica-core` → should be `core`
-- ❌ Outdated version: `0.8.3` → should be `0.9.0`
+- ❌ Outdated version: `0.9.0` → should be `0.9.3`
 
 **Correct Maven dependency**:
 ```xml
 <dependency>
    <groupId>org.pragmatica-lite</groupId>
    <artifactId>core</artifactId>
-   <version>0.9.0</version>
+   <version>0.9.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Pragmatica Lite Core 0.9.0 → 0.9.3, fixed deprecated Verify.ensure() syntax