### PR TITLE
Release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.1] - 2026-04-11
 
 ### Added
+- **`Promise.await()` forbidden in business logic** — new zero-tolerance rule; use `@TerminalOperation` for legitimate cases (CLI, fire-and-forget)
+- **Abandoned `Result`/`Promise` values** — new zero-tolerance rule; every value must be returned or handled
+- **`@Contract` and `@TerminalOperation` annotations** — dedicated annotations replace `@SuppressWarnings` for void return and await exemptions
+- **ndx section** in CLAUDE.md for recall palace quick reference
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-04-11
+
+### Added
+
+### Changed
+
 ## [2.3.0] - 2026-04-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,13 @@ For Java formatting rules, Pragmatica Core API reference, and JBCT patterns, see
 - **Tag versions** only after explicit command. Multiple changes may precede a tag.
 - **jbct-coder.md header**: Preserve during edits. Update description if needed; ask before changing other fields.
 - **PR merged** → check current branch; if not main, switch to main and pull.
+
+## ndx
+
+`ndx` is available in this project. Use `/ndx` for full CLI reference.
+
+Key commands: `ndx recall search "query"` (hybrid search), `ndx recall wake` (context), `ndx xref drawer <file>` (cross-ref).
+
+Skills: `/ndx-recall-classify`, `/ndx-recall-score`, `/ndx-recall-dedupe`, `/ndx-recall-contradict`, `/ndx-recall-summarize`, `/ndx-recall-handover`.
+
+If recall palace is not initialized, run `ndx recall init` then `ndx recall mine --from-memory`.

--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -6,7 +6,7 @@ description: "Revolutionary technology for writing deterministic, AI-friendly, h
 
 # Java Backend Coding Technology: Writing Code in the Era of AI
 
-**Version:** 2.3.0 | **Repository:** [github.com/siy/coding-technology](https://github.com/siy/coding-technology) | **Changelog:** [CHANGELOG.md](https://github.com/siy/coding-technology/blob/main/CHANGELOG.md)
+**Version:** 2.3.1 | **Repository:** [github.com/siy/coding-technology](https://github.com/siy/coding-technology) | **Changelog:** [CHANGELOG.md](https://github.com/siy/coding-technology/blob/main/CHANGELOG.md)
 
 ## Introduction: Code in a New Era
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Java Backend Coding Technology
 
-> **Version 2.3.0** | [Full Changelog](CHANGELOG.md)
+> **Version 2.3.1** | [Full Changelog](CHANGELOG.md)
 
 Executable business process specifications. Code that reads like a business process, because it is one. A framework-agnostic methodology for writing predictable, testable Java backend code optimized for human-AI collaboration.
 
@@ -243,7 +243,7 @@ void username_acceptsValidInput() {
 ### Changelog & Versioning
 
 - **[CHANGELOG.md](CHANGELOG.md)** - Version history following [Keep a Changelog](https://keepachangelog.com/)
-  - Current version: 2.3.0 (2026-03-27)
+  - Current version: 2.3.1 (2026-03-27)
   - Golden formatting patterns, Pragmatica Core 1.0.0-rc1, 37 lint rules
   - Semantic versioning for documentation releases
 
@@ -409,6 +409,6 @@ If you find this useful, consider [sponsoring](https://github.com/sponsors/siy).
 
 ---
 
-**Version:** 2.3.0 | **Last Updated:** 2026-03-27 | **[Full Changelog](CHANGELOG.md)**
+**Version:** 2.3.1 | **Last Updated:** 2026-03-27 | **[Full Changelog](CHANGELOG.md)**
 
 **Copyright © 2025 Sergiy Yevtushenko. Released under the [MIT License](LICENSE).**

--- a/ai-tools/agents/jbct-coder.md
+++ b/ai-tools/agents/jbct-coder.md
@@ -20,6 +20,9 @@ Before reporting completion, you MUST:
    - `Result.failure(` / `Promise.failure(` (static failure factories)
    - `new <ValueObject>(` outside factory methods (constructor bypass)
    - `throw new` / `try {` in domain/usecase packages
+   - `.await()` in domain/usecase packages (must have `@TerminalOperation` if legitimate)
+   - `@SuppressWarnings` used instead of `@Contract` or `@TerminalOperation`
+   - Statement-style calls discarding `Result`/`Promise` return values
 4. **Fix all violations found** — do not report them, fix them
 5. **Only then** return the file summary
 6. **Backreference to spec/plan** — if a spec, plan, or requirements document was provided:
@@ -47,10 +50,12 @@ These are **strictly prohibited**. Stop and rewrite if you catch yourself writin
 | `try-catch` in business logic | `lift()` at adapter boundary |
 | Public constructors on validated types | Factory method with validation |
 | `Result.failure(cause)` / `Promise.failure(cause)` | `cause.result()` / `cause.promise()` |
-| `Void` type parameter | `Unit` (`Result<Unit>`, `Promise<Unit>`). Note: `void` return is OK for fire-and-forget |
+| `Void` type parameter | `Unit` (`Result<Unit>`, `Promise<Unit>`). Note: `void` return OK with `@Contract` (external API) or fire-and-forget |
 | Nested record implementing use case interface | Direct lambda return |
 | Multi-statement lambdas with `{}` | Extract to named method |
 | `Promise<Result<T>>` (nested error channels) | `Promise<T>` only |
+| `Promise.await()` in business logic | Stay in monadic chain (`flatMap`/`map`). OK in tests; use `@TerminalOperation` for CLI `main()` / fire-and-forget |
+| Abandoned `Result`/`Promise` values | Every Result/Promise must be returned or handled. Method bodies = single return expression |
 
 ---
 

--- a/ai-tools/agents/jbct-reviewer.md
+++ b/ai-tools/agents/jbct-reviewer.md
@@ -28,11 +28,14 @@ Run these searches and report ALL hits:
 | Impl classes | `class.*Impl` | Use lambdas/method refs |
 | Null in business logic | `== null`, `!= null`, `return null` in domain/usecase | Use `Option<T>` |
 | Business exceptions | `throw new`, `throws \w`, `try {`, `catch (` in domain/usecase | Use `Result`/`Promise` with `Cause` |
-| Void type parameter | `Result<Void>`, `Promise<Void>` | Use `Unit`. Note: `void` return is OK for fire-and-forget |
+| Void type parameter | `Result<Void>`, `Promise<Void>` | Use `Unit`. `void` return OK with `@Contract` (external API) or fire-and-forget |
 | Static failure factories | `Result.failure(`, `Promise.failure(` | Use `cause.result()`/`cause.promise()` |
 | Multi-statement lambdas | `-> {` | Extract to named method |
 | Constructor bypass | `new ValueObject(` outside factory | Use factory method |
 | Nested error channels | `Promise<Result<` | Use `Promise<T>` only |
+| Blocking in business logic | `.await()` in domain/usecase without `@TerminalOperation` | Stay in monadic chain. OK in tests; legitimate uses require `@TerminalOperation` |
+| `@SuppressWarnings` misuse | `@SuppressWarnings` instead of `@Contract`/`@TerminalOperation` | Use dedicated annotations for void return (`@Contract`) and await (`@TerminalOperation`) |
+| Abandoned values | Statement-style calls to methods returning `Result`/`Promise` without using return value | Every Result/Promise must be returned or chained |
 
 **If ANY count > 0, those are confirmed violations.**
 

--- a/ai-tools/skills/jbct/SKILL.md
+++ b/ai-tools/skills/jbct/SKILL.md
@@ -69,10 +69,13 @@ These patterns are **never acceptable** in JBCT code. Hunt for them aggressively
 | Null checks in business logic | `if (x == null)` or `!= null` | Use `Option<T>` instead |
 | Throwing exceptions | `throw new` in business code | Use `Result<T>` or `Promise<T>` |
 | Catching exceptions | `catch` in business code | Lift at adapter boundaries only |
-| `Void` type parameter | `Result<Void>`, `Promise<Void>` | Use `Unit` type. Note: `void` return is OK for fire-and-forget |
+| `Void` type parameter | `Result<Void>`, `Promise<Void>` | Use `Unit`. `void` return OK with `@Contract` (external API) or fire-and-forget |
 | `Result.failure(cause)` | Direct call | Use `cause.result()` fluent style |
 | `Promise.failure(cause)` | Direct call | Use `cause.promise()` fluent style |
 | Multi-statement lambdas | `x -> { stmt1; stmt2; }` | Extract to named method |
+| `Promise.await()` in business logic | `.await()` in domain/usecase | Blocks thread. Stay in chain. OK in tests; use `@TerminalOperation` for CLI/fire-and-forget |
+| `@SuppressWarnings` misuse | Used instead of `@Contract`/`@TerminalOperation` | Use `@Contract` for void return (external API), `@TerminalOperation` for legitimate `await()` |
+| Abandoned `Result`/`Promise` | Statement discarding return value | Every Result/Promise must be returned or handled |
 
 **Exception:** Methods annotated with `@Contract` are exempt from all JBCT lint rules. Use `@Contract` for Java API boundary methods (annotation processors, Maven Mojos).
 

--- a/book/TABLE_OF_CONTENTS.md
+++ b/book/TABLE_OF_CONTENTS.md
@@ -1,7 +1,7 @@
 # Java Backend Coding Technology
 ## Unified Code Through Functional Composition
 
-**Based on:** JBCT v2.3.0 | **Pragmatica Core:** 1.0.0-rc1
+**Based on:** JBCT v2.3.1 | **Pragmatica Core:** 1.0.0-rc1
 
 ---
 

--- a/book/ch01-introduction.md
+++ b/book/ch01-introduction.md
@@ -1,6 +1,6 @@
 # Chapter 1: Introduction - Code Unification
 
-**Based on:** JBCT v2.3.0 | **Pragmatica Core:** 1.0.0-rc1
+**Based on:** JBCT v2.3.1 | **Pragmatica Core:** 1.0.0-rc1
 
 ## What You'll Learn
 

--- a/book/manuscript/ch01-introduction.md
+++ b/book/manuscript/ch01-introduction.md
@@ -1,6 +1,6 @@
 # Chapter 1: Introduction - Code Unification
 
-**Based on:** JBCT v2.3.0 | **Pragmatica Core:** 1.0.0-rc1
+**Based on:** JBCT v2.3.1 | **Pragmatica Core:** 1.0.0-rc1
 
 ## What You'll Learn
 

--- a/series/INDEX.md
+++ b/series/INDEX.md
@@ -1,6 +1,6 @@
 # Java Backend Coding Technology: Complete Learning Series
 
-**Based on:** [CODING_GUIDE.md](../CODING_GUIDE.md) v2.3.0
+**Based on:** [CODING_GUIDE.md](../CODING_GUIDE.md) v2.3.1
 
 ## About This Series
 


### PR DESCRIPTION
## Summary
- Add `Promise.await()` forbidden-in-business-logic rule with `@TerminalOperation` annotation for exemptions
- Add abandoned `Result`/`Promise` values rule — expression-based code enforcement
- Add `@Contract`/`@TerminalOperation` annotations replacing `@SuppressWarnings` misuse
- Add ndx recall palace section to CLAUDE.md

## Test plan
- [ ] Verify AI skill/agent files load correctly
- [ ] Build books after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)