### PR TITLE
Site refresh: current version stamps, honest Aether framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 > **Scope:** this file tracks the repository and shared assets — tooling, AI skills,
-> `CODING_GUIDE.md`, build scripts, and Pragmatica Core version bumps. Each book now
+> build scripts, and Pragmatica Core version bumps. Each book now
 > versions independently with its own reader-facing changelog: `book/CHANGELOG.md`
 > (JBCT) and `book-pfd/CHANGELOG.md` (PFD). See `BOOK-VERSIONING.md`. Pre-existing
 > entries below that describe book content are kept as history.

--- a/MANAGEMENT_PERSPECTIVE.md
+++ b/MANAGEMENT_PERSPECTIVE.md
@@ -1,6 +1,6 @@
 # The Engineering Scalability Crisis: Why Standard Code Structures Matter More Than Ever
 
-**Version:** 2.0.0 | **For:** CTOs, VPs of Engineering, CEOs | **By:** [Pragmatica Labs](https://pragmaticalabs.io)
+**Version:** 2.0.1 | **For:** CTOs, VPs of Engineering, CEOs | **By:** [Pragmatica Labs](https://pragmaticalabs.io)
 
 ## The $3 Million Question
 
@@ -289,7 +289,7 @@ JBCT solves how code gets written. But standardized code unlocks something bigge
 
 Every Java microservice today bundles a heavy coat of infrastructure -- web servers, serialization frameworks, service discovery clients, configuration management, health checks, metrics libraries, retry logic, circuit breakers. Your `pom.xml` doesn't distinguish business dependencies from infrastructure dependencies. They compile together, deploy together, and break together.
 
-[Pragmatica Aether](https://pragmaticalabs.io/aether.html) is a distributed Java runtime that separates these layers. When your code follows JBCT patterns, the step to distributed deployment is mechanical:
+[Pragmatica Aether](https://pragmaticalabs.io/aether.html) is a distributed Java runtime, currently in pre-release development, that separates these layers. When your code follows JBCT patterns, the step to distributed deployment is mechanical:
 
 ```java
 @Slice
@@ -313,7 +313,7 @@ An interface annotated with `@Slice`, plus business logic. No HTTP clients, no s
 Promise.lift(() -> legacyService.generate(request));
 ```
 
-Start in Aether Ember -- a single-process runtime that runs alongside your existing application in the same JVM. No risk added. From there, the strangler fig pattern: extract a hot path, deploy as a slice, route traffic, repeat. One sprint to first slice in production.
+The adoption path is designed to be low-risk: start in Aether Ember -- a single-process runtime that runs alongside your existing application in the same JVM. No risk added. From there, the strangler fig pattern: extract a hot path, deploy as a slice, route traffic, repeat. The target: one sprint to first slice in production.
 
 **The economic impact compounds what JBCT delivers**:
 
@@ -497,6 +497,6 @@ Start small. Measure rigorously. Scale deliberately.
 
 ---
 
-**Document Version**: 2.0.0 (2026-02-13)
+**Document Version**: 2.0.1 (2026-07-03)
 **Author**: [Pragmatica Labs](https://pragmaticalabs.io) -- Pragmatic Solutions for Java Teams
 **Technical Reference**: [JBCT book](book/index.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Java Backend Coding Technology
 
-> **Version 4.1.1** | [Full Changelog](book/CHANGELOG.md)
+> **Version 4.2.1** | [Full Changelog](book/CHANGELOG.md)
 
 Executable business process specifications. Code that reads like a business process, because it is one. A framework-agnostic methodology for writing predictable, testable Java backend code optimized for human-AI collaboration.
 
@@ -217,7 +217,7 @@ void username_acceptsValidInput() {
 ### Changelog & Versioning
 
 - **[Book changelog](book/CHANGELOG.md)** - Version history following [Keep a Changelog](https://keepachangelog.com/)
-  - Current version: 4.1.1 (2026-06-25)
+  - Current version: 4.2.1 (2026-06-30)
   - Self-contained design-to-code methodology on Pragmatica Core 1.0.0-rc1
   - Per-book semantic versioning across the JBCT and PFD books
 
@@ -280,19 +280,18 @@ curl -fsSL https://raw.githubusercontent.com/siy/jbct-cli/main/install.sh | sh
 coding-technology/
 ├── book/                        # JBCT book (web edition + source)
 │   ├── index.md                 # Table of contents
-│   ├── ch01-*.md ... ch11-*.md  # Book chapters
+│   ├── ch01-*.md ... ch19-*.md  # Book chapters
+│   ├── appendix-*.md            # Appendices (API reference, exercises, glossary)
 │   └── CHANGELOG.md             # Book version history
 ├── MANAGEMENT_PERSPECTIVE.md    # Business case and ROI
 ├── CHANGELOG.md                 # Version history
 ├── AI-TOOLING.md                # AI tools documentation
 ├── CLI-TOOLING.md               # CLI tools documentation
 ├── MAVEN-PLUGIN.md              # Maven plugin documentation
-├── skills/                      # Claude Code skills
-│   ├── jbct/                    # JBCT main skill
-│   │   ├── SKILL.md             # Skill definition
-│   │   └── README.md            # Installation instructions
-│   └── jbct-review/             # Parallel review skill
-│       └── SKILL.md             # /jbct-review command
+├── ai-tools/                    # Claude Code skills and agents
+│   ├── skills/jbct/             # JBCT main skill
+│   ├── skills/jbct-review/      # Parallel review skill (/jbct-review)
+│   └── agents/                  # Subagent definitions
 ├── jbct-coder.md                # Claude Code subagent: code generation
 ├── jbct-reviewer.md             # Claude Code subagent: code review
 ├── examples/                    # Java code examples
@@ -375,6 +374,6 @@ If you find this useful, consider [sponsoring](https://github.com/sponsors/siy).
 
 ---
 
-**Version:** 4.1.1 | **Last Updated:** 2026-06-25 | **[Full Changelog](book/CHANGELOG.md)**
+**Version:** 4.2.1 | **Last Updated:** 2026-06-30 | **[Full Changelog](book/CHANGELOG.md)**
 
-**Copyright © 2025 Sergiy Yevtushenko. Released under the [MIT License](LICENSE).**
+**Copyright © 2025-2026 Sergiy Yevtushenko. Released under the [MIT License](LICENSE).**


### PR DESCRIPTION
Staleness audit fixes: homepage/footer JBCT version 4.1.1 -> 4.2.1 (three spots), repo tree corrected (ch19 + appendices, ai-tools/ layout), retired CODING_GUIDE.md removed from changelog scope note, Management page frames Aether as pre-release (runtime intro, adoption path as designed/target), document stamp refreshed. Verified: 37-lint-rule count correct, all internal links resolve, $25 Leanpub price matches.