### PR TITLE
Homepage: modernize Username example to Verify/Is idiom

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,10 @@ public class CreateUserRequest {
 ```java
 // Domain-specific value object
 public record Username(String value) {
-    private static final Cause BLANK = Causes.cause("Username is required");
-    private static final Cause TOO_SHORT = Causes.cause("Username must be at least 3 characters");
-
     public static Result<Username> username(String raw) {
-        return Verify.ensure(raw, Verify.Is::present, BLANK)
+        return Verify.ensure(raw, Verify.Is::present)
                      .map(String::trim)
-                     .filter(TOO_SHORT, v -> v.length() >= 3)
+                     .flatMap(v -> Verify.ensure(v, Verify.Is::lenBetween, 3, 50))
                      .map(Username::new);
     }
 }


### PR DESCRIPTION
Length check via parameterized Verify.Is::lenBetween (3, 50 — mirrors the @Size annotation in the before-example) instead of a capturing lambda with hand-rolled Cause constants. Matches the canonical factory example in Verify.java's own API docs (Pragmatica Core 1.0.0-rc1). Down-page test snippets unaffected.