### PR TITLE
Landing page split from GitHub README

### DIFF
--- a/website/build.js
+++ b/website/build.js
@@ -24,7 +24,7 @@ const SITE_URL = 'https://pragmatica.dev';
 
 // Pages to build: repo-relative source -> dist-relative output
 const PAGES = [
-  { src: 'README.md', out: 'index.html' },
+  { src: 'website/content/index.md', out: 'index.html' },
   { src: 'website/content/books.md', out: 'books.html' },
   { src: 'MANAGEMENT_PERSPECTIVE.md', out: 'MANAGEMENT_PERSPECTIVE.html' },
   { src: 'CHANGELOG.md', out: 'CHANGELOG.html' },
@@ -162,6 +162,21 @@ function convertMarkdownToHtml(markdownContent, filename, isSubPage = false, nav
   const { body, attributes: metadata } = stripFrontMatter(markdownContent);
   let content = body;
 
+  // Re-target relative .md links: resolve against the source file's real
+  // directory, then re-relativize to the output page's directory. Sources that
+  // live elsewhere than their output (symlinked pages like AI-TOOLING.md ->
+  // ai-tools/README.md) keep working links both on GitHub and on the site.
+  if (pageMeta.srcDir !== undefined && pageMeta.outDir !== undefined) {
+    content = content.replace(/\]\(([^)#:\s]+\.md)((?:#[^)]*)?)\)/g, (match, target, anchor) => {
+      if (target.startsWith('/')) {
+        return match;
+      }
+      const resolved = path.posix.normalize(path.posix.join(pageMeta.srcDir, target));
+      const relinked = path.posix.relative(pageMeta.outDir, resolved) || resolved;
+      return `](${relinked}${anchor})`;
+    });
+  }
+
   // Convert markdown links to HTML links
   content = content.replace(/\.md(#[^)]*)?(\))/g, '.html$1$2');
 
@@ -217,7 +232,10 @@ function buildPage(sourceFile, outputFile, isSubPage = false, navKey = '', chapt
   const pageMeta = {
     canonicalUrl: relPath === 'index.html' ? SITE_URL + '/' : `${SITE_URL}/${relPath}`,
     description: DESCRIPTIONS[relPath],
-    ogType: relPath.startsWith('book/') ? 'article' : 'website'
+    ogType: relPath.startsWith('book/') ? 'article' : 'website',
+    // Real source dir (resolves symlinked pages) and output dir, both POSIX-relative
+    srcDir: path.relative(ROOT_DIR, path.dirname(fs.realpathSync(sourceFile))).split(path.sep).join('/'),
+    outDir: path.dirname(relPath) === '.' ? '' : path.dirname(relPath)
   };
 
   const markdown = fs.readFileSync(sourceFile, 'utf-8');

--- a/website/content/index.md
+++ b/website/content/index.md
@@ -1,0 +1,74 @@
+# Java Backend Coding Technology
+
+Executable business process specifications. Code that reads like a business process, because it is one. A framework-agnostic methodology for writing predictable, testable Java backend code optimized for human-AI collaboration.
+
+<p class="cta-row"><a class="cta cta-primary" href="book/index.html">Read the book free</a> <a class="cta" href="books.html">Books</a> <a class="cta" href="CONTACT.html">Work with us</a></p>
+
+## Here's what changes
+
+**Without JBCT**
+
+```java
+// Hidden failure modes, unclear control flow
+public User findUser(String userId) throws NotFoundException {
+    long id;
+    try {
+        id = Long.parseLong(userId);
+    } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Invalid user ID");
+    }
+
+    User user = repository.findById(id);
+    if (user == null) {
+        throw new NotFoundException("User not found: " + id);
+    }
+
+    return user;
+    // Multiple failure modes hidden in throws
+    // Caller must read docs to know what exceptions to catch
+}
+```
+
+**With JBCT**
+
+```java
+// Parse don't validate - invalid states unrepresentable
+public record UserId(long value) {
+    // Records can't hide the canonical constructor; userId() is the construction path
+
+    public static Result<UserId> userId(String raw) {
+        return Number.parseLong(raw)
+                     .map(UserId::new);
+    }
+}
+
+public interface FindUser {
+    Promise<User> execute(UserId id);
+}
+
+// Usage
+UserId.userId(userIdStr)
+      .async()
+      .flatMap(findUser::execute)
+      // Parsing errors: Result<UserId>
+      // Not found errors: Promise<User>
+      // All failures typed, compiler enforces handling
+```
+
+**Result:** Parse-don't-validate makes invalid states impossible. Typed errors eliminate hidden exceptions. Type signatures document failure modes.
+
+## One discipline, from design to deployment
+
+- **Design — [Process-First Design](books.html).** The unit of design is the process, not the entity. The methodology book: how the structure of a backend is derived from what the business does, not from a data model. The condensed edition is free — the whole argument in about 25 minutes.
+- **Code — [Java Backend Coding Technology](book/index.html).** The Java realization this site documents: typed failures, parse-don't-validate, composition patterns, testing strategy, worked examples. The complete book is free to read online.
+- **Run — [Pragmatica Aether](https://pragmaticalabs.io/aether.html).** A distributed Java runtime, currently in pre-release development, where the same composition deploys unchanged — business logic stays free of infrastructure code.
+
+## Where to start
+
+- **Developers** — read the [book](book/index.html), then wire up the [AI and CLI tooling](AI-TOOLING.html).
+- **Engineering leaders** — the [management perspective](MANAGEMENT_PERSPECTIVE.html): the business case for structural standardization.
+- **Teams adopting** — [work with us](CONTACT.html): assessment, training, architecture review, adoption sprints.
+
+## Why "Technology"?
+
+A methodology tells you what good looks like; a technology makes it reproducible. JBCT ships with the pieces that make the discipline mechanical rather than aspirational: a [CLI linter](CLI-TOOLING.html) and [Maven plugin](MAVEN-PLUGIN.html) that enforce the structural rules, [AI skills and subagents](AI-TOOLING.html) that generate and review compliant code, and a [book](book/index.html) that derives every rule instead of decreeing it.

--- a/website/styles/style.css
+++ b/website/styles/style.css
@@ -195,6 +195,39 @@ main {
     white-space: nowrap;
 }
 
+/* Hero CTA row (landing page) */
+.cta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 2rem 0;
+}
+
+a.cta {
+    display: inline-block;
+    padding: 0.6rem 1.4rem;
+    border: 1px solid var(--primary-color);
+    border-radius: 6px;
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+a.cta:hover {
+    background-color: var(--primary-color);
+    color: #fff;
+}
+
+a.cta-primary {
+    background-color: var(--primary-color);
+    color: #fff;
+}
+
+a.cta-primary:hover {
+    opacity: 0.9;
+}
+
 /* Book cards (Books page) */
 .book-card {
     display: flex;


### PR DESCRIPTION
Site homepage now builds from website/content/index.md: hero with CTA buttons, Without/With code teaser, design-code-run ecosystem arc (Aether marked pre-release), audience paths, Why-Technology. Repo README no longer built (stays GitHub-facing, unchanged). Bonus: relative .md links are now resolved against each source's real directory then re-relativized to output - fixes 6 pre-existing broken links on AI-TOOLING.html (symlinked source). Dist-wide internal link check: 0 broken.