### PR TITLE
End-of-book funnel CTAs

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -75,3 +75,11 @@
 | [Appendix A: Pragmatica Core API Reference](appendix-a-api-reference.md) | Complete API reference for Result, Option, Promise, and utility types. |
 | [Appendix B: Exercises and Solutions](appendix-b-exercises.md) | Practice exercises for each major topic with worked solutions. |
 | [Appendix C: Glossary](appendix-c-glossary.md) | Definitions for every term used throughout the book. |
+
+---
+
+## Beyond the web edition
+
+- Prefer a file? [PDF/EPUB on Leanpub](https://leanpub.com/jbct-book) — $25, updates included.
+- The design methodology upstream of JBCT: [Process-First Design](../books.html) — the condensed edition is free.
+- Adopting with a team? [Work with us](../CONTACT.html) — assessment, training, adoption sprints.

--- a/website/build.js
+++ b/website/build.js
@@ -157,7 +157,20 @@ function buildChapterNav(prev, next) {
   return `<nav class="chapter-nav {{POS}}">${prevLink}${contents}${nextLink}</nav>\n`;
 }
 
-function convertMarkdownToHtml(markdownContent, filename, isSubPage = false, navKey = '', chapterNav = '', pageMeta = {}) {
+// Shown once, after the bottom nav of the final reading-sequence page.
+// Injected at build time so the book sources stay clean for PDF/EPUB builds.
+const WHATS_NEXT_HTML = `
+<aside class="whats-next">
+  <h2>You've finished the web edition — what's next?</h2>
+  <ul>
+    <li><a href="https://leanpub.com/jbct-book" target="_blank" rel="noopener">Take it with you</a> — the book as PDF/EPUB on Leanpub.</li>
+    <li><a href="https://leanpub.com/process-first-design" target="_blank" rel="noopener">Read the methodology upstream</a> — Process-First Design; the condensed edition is free.</li>
+    <li><a href="{{NAV_CONTEXT}}CONTACT.html">Bring it to your team</a> — assessment, training, and adoption sprints.</li>
+  </ul>
+</aside>
+`;
+
+function convertMarkdownToHtml(markdownContent, filename, isSubPage = false, navKey = '', chapterNav = '', pageMeta = {}, afterContent = '') {
   // Strip front matter (tolerant of colon-bearing values)
   const { body, attributes: metadata } = stripFrontMatter(markdownContent);
   let content = body;
@@ -196,6 +209,9 @@ function convertMarkdownToHtml(markdownContent, filename, isSubPage = false, nav
   if (chapterNav) {
     htmlContent = chapterNav.replace('{{POS}}', 'top') + htmlContent + chapterNav.replace('{{POS}}', 'bottom');
   }
+  if (afterContent) {
+    htmlContent += afterContent;
+  }
 
   // Load template
   const template = readTemplate('page');
@@ -224,7 +240,7 @@ function convertMarkdownToHtml(markdownContent, filename, isSubPage = false, nav
   return html;
 }
 
-function buildPage(sourceFile, outputFile, isSubPage = false, navKey = '', chapterNav = '') {
+function buildPage(sourceFile, outputFile, isSubPage = false, navKey = '', chapterNav = '', afterContent = '') {
   console.log(`Building: ${sourceFile} -> ${outputFile}`);
 
   // Dist-relative path drives canonical URL, description lookup, and og:type
@@ -239,7 +255,7 @@ function buildPage(sourceFile, outputFile, isSubPage = false, navKey = '', chapt
   };
 
   const markdown = fs.readFileSync(sourceFile, 'utf-8');
-  const html = convertMarkdownToHtml(markdown, path.basename(sourceFile), isSubPage, navKey, chapterNav, pageMeta);
+  const html = convertMarkdownToHtml(markdown, path.basename(sourceFile), isSubPage, navKey, chapterNav, pageMeta, afterContent);
 
   ensureDir(path.dirname(outputFile));
   fs.writeFileSync(outputFile, html);
@@ -326,10 +342,12 @@ function buildBookPages() {
     })
     .filter(Boolean);
 
-  // Build each reading-sequence page with prev / Contents / next navigation
+  // Build each reading-sequence page with prev / Contents / next navigation;
+  // the final page additionally gets the what's-next block.
   sequence.forEach((chapter, i) => {
     const chapterNav = buildChapterNav(sequence[i - 1], sequence[i + 1]);
-    buildPage(chapter.sourcePath, path.join(bookDistDir, chapter.htmlName), true, 'books', chapterNav);
+    const afterContent = i === sequence.length - 1 ? WHATS_NEXT_HTML : '';
+    buildPage(chapter.sourcePath, path.join(bookDistDir, chapter.htmlName), true, 'books', chapterNav, afterContent);
   });
 
   // CHANGELOG: Contents link only, no prev/next

--- a/website/styles/style.css
+++ b/website/styles/style.css
@@ -228,6 +228,23 @@ a.cta-primary:hover {
     opacity: 0.9;
 }
 
+/* What's-next block (final book page) */
+.whats-next {
+    margin-top: 2.5rem;
+    padding: 1.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+}
+
+.whats-next h2 {
+    margin-top: 0;
+    font-size: 1.3rem;
+}
+
+.whats-next ul {
+    margin-bottom: 0;
+}
+
 /* Book cards (Books page) */
 .book-card {
     display: flex;


### PR DESCRIPTION
Build-time what's-next block after the bottom nav of the final reading-sequence page only (book sources stay clean for PDF/EPUB); matching Beyond-the-web-edition footer on the web-only book TOC; quiet .whats-next styling. Verified: block on appendix-c only, 0 broken internal links.