### PR TITLE
Cache-bust stylesheet URL with content hash

### DIFF
--- a/website/build.js
+++ b/website/build.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const MarkdownIt = require('markdown-it');
 const markdownItAnchor = require('markdown-it-anchor');
 
@@ -21,6 +22,13 @@ const DIST_DIR = path.join(__dirname, 'dist');
 const TEMPLATES_DIR = path.join(__dirname, 'templates');
 const STYLES_DIR = path.join(__dirname, 'styles');
 const SITE_URL = 'https://pragmatica.dev';
+
+// Content hash for the stylesheet URL: the CDN caches /*.css as immutable
+// for a year (netlify.toml), so every CSS change must change the URL.
+const STYLE_HASH = crypto.createHash('md5')
+                         .update(fs.readFileSync(path.join(STYLES_DIR, 'style.css')))
+                         .digest('hex')
+                         .slice(0, 10);
 
 // Pages to build: repo-relative source -> dist-relative output
 const PAGES = [
@@ -229,6 +237,7 @@ function convertMarkdownToHtml(markdownContent, filename, isSubPage = false, nav
     .replace(/{{DESCRIPTION}}/g, escapeAttr(description))
     .replace(/{{CANONICAL_URL}}/g, pageMeta.canonicalUrl || SITE_URL + '/')
     .replace(/{{OG_TYPE}}/g, pageMeta.ogType || 'website')
+    .replace(/{{STYLE_HASH}}/g, STYLE_HASH)
     .replace('{{CONTENT}}', () => htmlContent)
     .replace(/{{NAV_CONTEXT}}/g, navContext);
 

--- a/website/templates/page.html
+++ b/website/templates/page.html
@@ -10,7 +10,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="{{NAV_CONTEXT}}image/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="{{NAV_CONTEXT}}image/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="{{NAV_CONTEXT}}image/apple-touch-icon.png">
-    <link rel="stylesheet" href="{{NAV_CONTEXT}}style.css">
+    <link rel="stylesheet" href="{{NAV_CONTEXT}}style.css?v={{STYLE_HASH}}">
     <link rel="canonical" href="{{CANONICAL_URL}}">
     <!-- Social sharing -->
     <meta property="og:title" content="{{TITLE}} | Pragmatica">


### PR DESCRIPTION
netlify.toml serves /*.css with max-age=31536000 immutable, but pages referenced a fixed /style.css URL - so every CSS change (including today's CTA readability fix) stayed invisible behind the edge cache until eviction. The stylesheet href now carries a build-time md5 content hash (?v=<hash>); any CSS change changes the URL and busts the cache. Verified in dist on main and book pages.