### PR TITLE
fix: AS Leanpub slug

### DIFF
--- a/website/content/architecture-synthesis.md
+++ b/website/content/architecture-synthesis.md
@@ -8,4 +8,4 @@ A practicing architect can start here directly; a reader arriving from Process-F
 
 Four architectures have been derived blind, against a locked answer sheet, and graded against what those systems actually run — in the open, with the misses shown alongside the hits. The registered predictions, answer sheets, operator prompts, and grading rubrics are public in a [replication kit](https://github.com/siy/derivation-artifacts). Every derivation after the first four is registered there before its outcome is checked, and counterexamples are invited.
 
-The book — [*Architecture Synthesis: The Next Correct Step*](https://leanpub.com/architecture-synthesis) — is on Leanpub. A course edition follows.
+The book — [*Architecture Synthesis: The Next Correct Step*](https://leanpub.com/architecture-synthesis-the-next-correct-step) — is on Leanpub. A course edition follows.

--- a/website/templates/front-door.html
+++ b/website/templates/front-door.html
@@ -123,7 +123,7 @@
         <circle cx="12" cy="32" r="3.4" fill="#f59e0b" stroke="#1a2840" stroke-width="1.2"/></svg>
       <h3>Architecture Synthesis</h3>
       <p>The next correct step: architecture derived, not chosen.</p>
-      <div class="row"><a class="btn soon" href="/method/architecture-synthesis/">Course planned</a><a class="btn book" href="https://leanpub.com/architecture-synthesis" target="_blank" rel="noopener">Book</a></div>
+      <div class="row"><a class="btn soon" href="/method/architecture-synthesis/">Course planned</a><a class="btn book" href="https://leanpub.com/architecture-synthesis-the-next-correct-step" target="_blank" rel="noopener">Book</a></div>
     </div>
     <div class="card">
       <svg width="72" height="72" viewBox="0 0 72 72"><g stroke="#1a2840" stroke-width="1.6" fill="none">


### PR DESCRIPTION
Point the AS Book links at the final Leanpub slug: architecture-synthesis-the-next-correct-step. Follow-up to the release-train merge (#35).