### PR TITLE
fix: theme toggle + author link

### DIFF
--- a/website/styles/style.css
+++ b/website/styles/style.css
@@ -44,6 +44,24 @@
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* Theme toggle — floating control, restored 2026-07-19 (redesign dropped it).
+   The data-theme tokens above already drive the whole palette; this is the switch. */
+.theme-toggle {
+  position: fixed; right: 1rem; bottom: 1rem; z-index: 100;
+  width: 2.75rem; height: 2.75rem; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  padding: 0; font-size: 1.15rem; line-height: 1; cursor: pointer;
+  background: var(--paper-raised); color: var(--ink);
+  border: 1px solid var(--line);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, .12);
+  transition: transform .12s ease, border-color .15s ease, box-shadow .15s ease;
+}
+.theme-toggle:hover { transform: translateY(-2px); border-color: var(--amber); box-shadow: 0 4px 16px rgba(0, 0, 0, .18); }
+.theme-toggle:focus-visible { outline: 2px solid var(--amber); outline-offset: 2px; }
+.theme-toggle .theme-icon { pointer-events: none; }
+@media (prefers-reduced-motion: reduce) { .theme-toggle { transition: none; } }
+@media print { .theme-toggle { display: none; } }
+
 html { scroll-behavior: smooth; }
 
 body {

--- a/website/templates/course-toc.html
+++ b/website/templates/course-toc.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<script>(function(){try{var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
 <meta name="description" content="{{DESCRIPTION}}">
 <meta name="author" content="Sergiy Yevtushenko">
 <title>{{TITLE}}</title>
@@ -53,5 +54,7 @@
   </div>
 </footer>
 
+<button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle light or dark theme"><span class="theme-icon" aria-hidden="true">🌙</span></button>
+<script>(function(){var b=document.getElementById('theme-toggle');if(!b)return;var i=b.querySelector('.theme-icon');function s(t){i.textContent=t==='dark'?'☀️':'🌙';}s(document.documentElement.getAttribute('data-theme'));b.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark';document.documentElement.setAttribute('data-theme',c);try{localStorage.setItem('theme',c);}catch(e){}s(c);});})();</script>
 </body>
 </html>

--- a/website/templates/front-door.html
+++ b/website/templates/front-door.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<script>(function(){try{var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
 <meta name="description" content="{{DESCRIPTION}}">
 <meta name="author" content="Sergiy Yevtushenko">
 <title>{{TITLE}}</title>
@@ -140,9 +141,11 @@
 <footer>
   <div class="wrap">
     <div>pragmatica.dev &mdash; the education home of the series &middot; commercial: <a href="https://pragmaticalabs.io/" target="_blank" rel="noopener">pragmaticalabs.io</a></div>
-    <div><a href="https://leanpub.com/u/siy" target="_blank" rel="noopener">Leanpub</a> &middot; <a href="https://github.com/pragmaticalabs/pragmatica" target="_blank" rel="noopener">GitHub</a> &middot; <a href="/method/counterexamples/">Counterexamples</a></div>
+    <div><a href="https://leanpub.com/u/sergiy1yevtushenko" target="_blank" rel="noopener">Leanpub</a> &middot; <a href="https://github.com/pragmaticalabs/pragmatica" target="_blank" rel="noopener">GitHub</a> &middot; <a href="/method/counterexamples/">Counterexamples</a></div>
   </div>
 </footer>
 
+<button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle light or dark theme"><span class="theme-icon" aria-hidden="true">🌙</span></button>
+<script>(function(){var b=document.getElementById('theme-toggle');if(!b)return;var i=b.querySelector('.theme-icon');function s(t){i.textContent=t==='dark'?'☀️':'🌙';}s(document.documentElement.getAttribute('data-theme'));b.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark';document.documentElement.setAttribute('data-theme',c);try{localStorage.setItem('theme',c);}catch(e){}s(c);});})();</script>
 </body>
 </html>

--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<script>(function(){try{var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
 <meta name="description" content="{{DESCRIPTION}}">
 <meta name="author" content="Sergiy Yevtushenko">
 <title>{{TITLE}}</title>
@@ -49,9 +50,11 @@
 <footer>
   <div class="wrap">
     <div>pragmatica.dev &mdash; the education home of the series &middot; commercial: <a href="https://pragmaticalabs.io/" target="_blank" rel="noopener">pragmaticalabs.io</a></div>
-    <div><a href="https://leanpub.com/u/siy" target="_blank" rel="noopener">Leanpub</a> &middot; <a href="https://github.com/pragmaticalabs/pragmatica" target="_blank" rel="noopener">GitHub</a> &middot; <a href="/method/counterexamples/">Counterexamples</a></div>
+    <div><a href="https://leanpub.com/u/sergiy1yevtushenko" target="_blank" rel="noopener">Leanpub</a> &middot; <a href="https://github.com/pragmaticalabs/pragmatica" target="_blank" rel="noopener">GitHub</a> &middot; <a href="/method/counterexamples/">Counterexamples</a></div>
   </div>
 </footer>
 
+<button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle light or dark theme"><span class="theme-icon" aria-hidden="true">🌙</span></button>
+<script>(function(){var b=document.getElementById('theme-toggle');if(!b)return;var i=b.querySelector('.theme-icon');function s(t){i.textContent=t==='dark'?'☀️':'🌙';}s(document.documentElement.getAttribute('data-theme'));b.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark';document.documentElement.setAttribute('data-theme',c);try{localStorage.setItem('theme',c);}catch(e){}s(c);});})();</script>
 </body>
 </html>

--- a/website/templates/lesson.html
+++ b/website/templates/lesson.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<script>(function(){try{var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
 <meta name="description" content="{{DESCRIPTION}}">
 <meta name="author" content="Sergiy Yevtushenko">
 <title>{{TITLE}}</title>
@@ -92,5 +93,7 @@
 })();
 </script>
 
+<button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle light or dark theme"><span class="theme-icon" aria-hidden="true">🌙</span></button>
+<script>(function(){var b=document.getElementById('theme-toggle');if(!b)return;var i=b.querySelector('.theme-icon');function s(t){i.textContent=t==='dark'?'☀️':'🌙';}s(document.documentElement.getAttribute('data-theme'));b.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark';document.documentElement.setAttribute('data-theme',c);try{localStorage.setItem('theme',c);}catch(e){}s(c);});})();</script>
 </body>
 </html>

--- a/website/templates/page.html
+++ b/website/templates/page.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<script>(function(){try{var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
 <meta name="description" content="{{DESCRIPTION}}">
 <meta name="author" content="Sergiy Yevtushenko">
 <title>{{TITLE}}</title>
@@ -50,5 +51,7 @@
   </div>
 </footer>
 
+<button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle light or dark theme"><span class="theme-icon" aria-hidden="true">🌙</span></button>
+<script>(function(){var b=document.getElementById('theme-toggle');if(!b)return;var i=b.querySelector('.theme-icon');function s(t){i.textContent=t==='dark'?'☀️':'🌙';}s(document.documentElement.getAttribute('data-theme'));b.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark';document.documentElement.setAttribute('data-theme',c);try{localStorage.setItem('theme',c);}catch(e){}s(c);});})();</script>
 </body>
 </html>


### PR DESCRIPTION
Two live-site fixes:
- Restore the light/dark theme toggle (dropped from redesign templates; CSS data-theme support was intact, the control was missing) as a floating button on all page types.
- Correct the Leanpub author link to /u/sergiy1yevtushenko.