### PR TITLE
PFD & Architecture Synthesis course editions

### DIFF
--- a/website/build.js
+++ b/website/build.js
@@ -42,6 +42,103 @@ const STYLE_HASH = crypto.createHash('md5')
 
 const SITEMAP_URLS = [];
 
+// ---------- Course registry (JBCT + PFD + AS) ----------
+// Each course renders its book's chapters as sequential web lessons. JBCT's config
+// reproduces the previously-hardcoded behaviour exactly (byte-identical output).
+
+const COURSES = [
+  {
+    id: 'jbct',
+    bookDir: path.join(ROOT_DIR, 'book'),
+    layerDir: path.join(__dirname, 'course', 'jbct'),
+    urlBase: '/java/jbct/course/',
+    referenceUrlBase: '/java/jbct/reference/',
+    referenceSlug: 'appendix-a-api-reference',
+    tocFileSlug: 'appendix-b-exercises',
+    glossarySlug: 'appendix-c-glossary',
+    storagePrefix: 'jbct:',
+    nav: 'java',
+    realm: { href: '/java/', label: 'The Java Realization' },
+    parent: { href: '/java/jbct/', label: 'JBCT course' },
+    courseLabel: 'JBCT course',
+    crumbLabel: 'JBCT course',
+    h1: 'Java Backend Coding Technology &mdash; Course',
+    titleSuffix: 'JBCT course',
+    tocTitle: 'JBCT Course — pragmatica.dev',
+    tocDescription: 'The full JBCT method, chapter by chapter: six parts, twenty-two lessons, each pairing book prose with a short exercise. Free, no account required.',
+    tocIntro: 'Twenty-two lessons across six parts. Each pairs the book’s prose with a short exercise; progress is tracked locally in your browser, no account required.',
+    footerLinks: '<a href="/java/jbct/reference/">API reference</a> &middot; <a href="https://leanpub.com/jbct-book" target="_blank" rel="noopener">Get the book</a> &middot; ',
+    nonLessonSlugs: new Set(['appendix-a-api-reference', 'appendix-b-exercises', 'appendix-c-glossary'])
+  },
+  {
+    id: 'pfd',
+    bookDir: path.join(ROOT_DIR, 'book-pfd'),
+    layerDir: path.join(__dirname, 'course', 'pfd'),
+    urlBase: '/method/pfd/course/',
+    referenceUrlBase: null,
+    referenceSlug: null,
+    tocFileSlug: null,
+    glossarySlug: 'glossary',
+    storagePrefix: 'pfd:',
+    nav: 'method',
+    realm: { href: '/method/', label: 'The Method' },
+    parent: { href: '/method/pfd/', label: 'Process-First Design' },
+    courseLabel: 'PFD course',
+    crumbLabel: 'PFD course',
+    h1: 'Process-First Design &mdash; Course',
+    titleSuffix: 'PFD course',
+    tocTitle: 'Process-First Design Course — pragmatica.dev',
+    tocDescription: 'Process-First Design, chapter by chapter: the spiral walked at four altitudes, each lesson pairing book prose with an apply-to-your-system exercise. Free, no account required.',
+    tocIntro: 'The whole method as a sequence of lessons. Each pairs the book’s prose with a short exercise you run on a system you own; progress is tracked locally in your browser, no account required.',
+    footerLinks: '<a href="https://leanpub.com/process-first-design" target="_blank" rel="noopener">Get the book</a> &middot; ',
+    nonLessonSlugs: new Set(['series-note', 'acknowledgments', 'afterword', 'glossary', 'references'])
+  },
+  {
+    id: 'as',
+    bookDir: path.join(ROOT_DIR, 'book-arch'),
+    layerDir: path.join(__dirname, 'course', 'architecture-synthesis'),
+    urlBase: '/method/architecture-synthesis/course/',
+    referenceUrlBase: '/method/architecture-synthesis/reference/',
+    referenceSlug: 'appendix-reference-cards',
+    tocFileSlug: null,
+    glossarySlug: 'glossary',
+    storagePrefix: 'as:',
+    nav: 'method',
+    realm: { href: '/method/', label: 'The Method' },
+    parent: { href: '/method/architecture-synthesis/', label: 'Architecture Synthesis' },
+    courseLabel: 'Architecture Synthesis course',
+    crumbLabel: 'Architecture Synthesis course',
+    h1: 'Architecture Synthesis &mdash; Course',
+    titleSuffix: 'Architecture Synthesis course',
+    tocTitle: 'Architecture Synthesis Course — pragmatica.dev',
+    tocDescription: 'Architecture Synthesis, chapter by chapter: derive an architecture from service-level objectives, verify it against its own budget, and grade it against real systems. Each lesson pairs book prose with an apply-to-your-system exercise. Free, no account required.',
+    tocIntro: 'The whole derivation method as a sequence of lessons. Each pairs the book’s prose with a short exercise you run on a system you own; progress is tracked locally in your browser, no account required.',
+    footerLinks: '<a href="/method/architecture-synthesis/reference/">Reference cards</a> &middot; <a href="https://leanpub.com/architecture-synthesis-the-next-correct-step" target="_blank" rel="noopener">Get the book</a> &middot; ',
+    nonLessonSlugs: new Set(['series-note', 'acknowledgments', 'appendix-worksheet', 'appendix-reference-cards', 'references'])
+  }
+];
+
+const courseByBookDir = {};
+COURSES.forEach(c => { courseByBookDir[path.basename(c.bookDir)] = c; });
+
+// Course-nav link list, reproducing the TOC template's original markup exactly
+// (no class on inactive links, class="current" on the active realm).
+function courseNavLinks(navKey) {
+  const a = (key, href, label) =>
+    `<a ${navKey === key ? 'class="current" ' : ''}href="${href}">${label}</a>`;
+  return [
+    a('start', '/', 'Start'),
+    a('method', '/method/', 'The Method'),
+    a('java', '/java/', 'The Java Realization'),
+    a('glossary', '/method/glossary/', 'Glossary'),
+    '<a href="https://github.com/pragmaticalabs/pragmatica" target="_blank" rel="noopener">GitHub</a>'
+  ].join('\n      ');
+}
+
+function courseOutSegs(course) {
+  return course.urlBase.replace(/^\/|\/$/g, '').split('/');
+}
+
 // ---------- Generic helpers ----------
 
 function ensureDir(dir) {
@@ -124,36 +221,29 @@ function walk(dir) {
 
 // ---------- Spine (book/root.md) ----------
 
-function parseSpine() {
-  const raw = fs.readFileSync(path.join(BOOK_DIR, 'root.md'), 'utf-8');
+function parseSpine(course) {
+  const raw = fs.readFileSync(path.join(course.bookDir, 'root.md'), 'utf-8');
   const lines = raw.split(/\r?\n/);
   const parts = [];
-  const backMatter = [];
   let current = null;
-  let inBackMatter = false;
 
   for (const line of lines) {
-    const partMatch = line.match(/^## (Part [IVX]+) — (.+)$/);
-    const backMatch = line.match(/^## Back matter\s*$/);
-    if (partMatch) {
-      current = { roman: partMatch[1].replace('Part ', ''), name: partMatch[2].trim(), lessons: [] };
+    const headMatch = line.match(/^## (.+?)\s*$/);
+    if (headMatch) {
+      current = { label: headMatch[1].trim(), lessons: [] };
       parts.push(current);
-      inBackMatter = false;
-      continue;
-    }
-    if (backMatch) {
-      current = null;
-      inBackMatter = true;
       continue;
     }
     const itemMatch = line.match(/^- \[(.+?)\]\(([a-z0-9-]+)\.md\)/);
-    if (itemMatch) {
-      const item = { title: itemMatch[1].trim(), slug: itemMatch[2].trim() };
-      if (current) current.lessons.push(item);
-      else if (inBackMatter) backMatter.push(item);
+    if (itemMatch && current) {
+      const slug = itemMatch[2].trim();
+      if (!course.nonLessonSlugs.has(slug)) {
+        current.lessons.push({ title: itemMatch[1].trim(), slug });
+      }
     }
   }
-  return { parts, backMatter };
+  // Sections with no lessons (front/back matter, notes) drop out entirely.
+  return parts.filter(p => p.lessons.length > 0);
 }
 
 function flattenSpine(parts) {
@@ -163,7 +253,7 @@ function flattenSpine(parts) {
       flat.push({
         slug: lesson.slug,
         specTitle: lesson.title,
-        partName: `Part ${part.roman} — ${part.name}`,
+        partName: part.label,
         partSlugs: part.lessons.map(l => l.slug),
         posInPart,
         partTotal: part.lessons.length
@@ -176,15 +266,24 @@ function flattenSpine(parts) {
 
 // ---------- Book-chapter link rewriting ----------
 
-function rewriteBookLinks(markdown, courseSlugSet) {
+function rewriteBookLinks(markdown, course, byBook) {
   return markdown.replace(/\]\(([^)#\s]+\.md)((?:#[^)]*)?)\)/g, (match, target, anchor) => {
-    const clean = target.replace(/^\.\//, '');
-    if (clean === 'appendix-a-api-reference.md') return `](/java/jbct/reference/${anchor || ''})`;
-    if (clean === 'appendix-c-glossary.md') return `](/method/glossary/${anchor || ''})`;
-    if (clean === 'appendix-b-exercises.md') return `](/java/jbct/course/)`;
+    let clean = target.replace(/^\.\//, '');
+    let cc = course;
+    // A ../book-*/ prefix targets another book → resolve against that course.
+    const cross = clean.match(/^\.\.\/([^/]+)\/(.+)$/);
+    if (cross) {
+      const other = byBook[cross[1]];
+      if (!other) return match;
+      cc = other;
+      clean = cross[2];
+    }
     const slug = clean.replace(/\.md$/, '');
-    if (courseSlugSet.has(slug)) return `](/java/jbct/course/${slug}/${anchor || ''})`;
-    console.warn(`  WARN: unrecognized book-internal link target "${target}" — left unresolved`);
+    if (slug === cc.glossarySlug) return `](/method/glossary/${anchor || ''})`;
+    if (cc.referenceSlug && slug === cc.referenceSlug) return `](${cc.referenceUrlBase}${anchor || ''})`;
+    if (cc.tocFileSlug && slug === cc.tocFileSlug) return `](${cc.urlBase})`;
+    if (cc.lessonSlugSet && cc.lessonSlugSet.has(slug)) return `](${cc.urlBase}${slug}/${anchor || ''})`;
+    console.warn(`  WARN: unrecognized book-internal link target "${target}" in ${course.id} — left unresolved`);
     return match;
   });
 }
@@ -193,7 +292,10 @@ function rewriteBookLinks(markdown, courseSlugSet) {
 
 function parseCourseLayer(raw) {
   const sections = {};
-  const re = /^## (blurb|learn|note|exercise)\s*\r?\n([\s\S]*?)(?=\r?\n## |\s*$)/gm;
+  // Capture each section's full body: everything up to the next "## " header or the
+  // true end of input. (A bare `$` under /m matches every line-end and truncates
+  // multi-line sections after their first line — hence `$(?![\s\S])` for real EOF.)
+  const re = /^## (blurb|learn|note|exercise)\s*\r?\n([\s\S]*?)(?=\r?\n## |$(?![\s\S]))/gm;
   let m;
   while ((m = re.exec(raw))) sections[m[1]] = m[2].trim();
   return sections;
@@ -308,6 +410,7 @@ const LANDING_PAGES = [
     src: 'website/content/pfd.md', out: 'method/pfd/index.html', fallbackTitle: 'Process-First Design',
     crumb: crumbSub('/method/', 'The Method', 'Process-First Design'), nav: 'method',
     related: [
+      { href: '/method/pfd/course/', label: 'PFD course', note: 'start learning' },
       { href: '/method/', label: 'The Method', note: 'parent' },
       { href: '/method/architecture-synthesis/', label: 'Architecture Synthesis', note: 'next step' },
       { href: '/method/glossary/', label: 'Series glossary', note: 'reference' }
@@ -317,6 +420,7 @@ const LANDING_PAGES = [
     src: 'website/content/architecture-synthesis.md', out: 'method/architecture-synthesis/index.html', fallbackTitle: 'Architecture Synthesis',
     crumb: crumbSub('/method/', 'The Method', 'Architecture Synthesis'), nav: 'method',
     related: [
+      { href: '/method/architecture-synthesis/course/', label: 'Architecture Synthesis course', note: 'start learning' },
       { href: '/method/', label: 'The Method', note: 'parent' },
       { href: '/method/pfd/', label: 'Process-First Design', note: 'upstream' },
       { href: '/method/glossary/', label: 'Series glossary', note: 'reference' }
@@ -370,6 +474,16 @@ const LANDING_PAGES = [
       { href: '/java/jbct/course/', label: 'JBCT course', note: 'back to contents' },
       { href: '/java/jbct/', label: 'Java Backend Coding Technology', note: 'overview' }
     ]
+  },
+  {
+    src: 'book-arch/appendix-reference-cards.md', out: 'method/architecture-synthesis/reference/index.html', fallbackTitle: 'Reference Cards',
+    crumb: crumbDeep([{ href: '/method/', label: 'The Method' }, { href: '/method/architecture-synthesis/course/', label: 'Architecture Synthesis course' }], 'Reference cards'),
+    nav: 'method',
+    description: 'The Architecture Synthesis reference cards: the nine questions, the ledger of axis values and costs, and the derivation rules — the whole method as a deck.',
+    related: [
+      { href: '/method/architecture-synthesis/course/', label: 'Architecture Synthesis course', note: 'back to contents' },
+      { href: '/method/architecture-synthesis/', label: 'Architecture Synthesis', note: 'overview' }
+    ]
   }
 ];
 
@@ -379,24 +493,24 @@ function buildLandingPages() {
 
 // ---------- Course TOC ----------
 
-function buildCourseToc(parts, flat) {
+function buildCourseToc(course, parts, flat) {
   const template = readTemplate('course-toc');
   const partsHtml = parts.map(part => {
     const slugs = part.lessons.map(l => l.slug);
     const svg = buildLatticeSVG(slugs, -1);
     const items = part.lessons.map((lesson, i) => {
-      const layerPath = path.join(COURSE_DIR, `${lesson.slug}.md`);
+      const layerPath = path.join(course.layerDir, `${lesson.slug}.md`);
       let blurb = '';
       if (fs.existsSync(layerPath)) {
         const sections = parseCourseLayer(fs.readFileSync(layerPath, 'utf-8'));
         blurb = sections.blurb || '';
       } else {
-        console.warn(`  WARN: course/jbct/${lesson.slug}.md not found — TOC blurb omitted`);
+        console.warn(`  WARN: ${course.id} course layer ${lesson.slug}.md not found — TOC blurb omitted`);
       }
-      return `<li><a href="/java/jbct/course/${lesson.slug}/"><span class="num">${i + 1}</span><span class="title">${escapeHtml(lesson.title)}</span>${blurb ? `<div class="blurb">${escapeHtml(blurb)}</div>` : ''}</a></li>`;
+      return `<li><a href="${course.urlBase}${lesson.slug}/"><span class="num">${i + 1}</span><span class="title">${escapeHtml(lesson.title)}</span>${blurb ? `<div class="blurb">${escapeHtml(blurb)}</div>` : ''}</a></li>`;
     }).join('\n      ');
     return `<div class="part-block">
-      <h2>Part ${part.roman} — ${escapeHtml(part.name)}</h2>
+      <h2>${escapeHtml(part.label)}</h2>
       <div class="part-cap">${part.lessons.length} lesson${part.lessons.length === 1 ? '' : 's'}</div>
       ${svg}
       <ul class="lesson-list">
@@ -405,45 +519,47 @@ function buildCourseToc(parts, flat) {
     </div>`;
   }).join('\n\n');
 
-  const title = 'JBCT Course — pragmatica.dev';
-  const description = 'The full JBCT method, chapter by chapter: six parts, twenty-two lessons, each pairing book prose with a short exercise. Free, no account required.';
-  const intro = 'Twenty-two lessons across six parts. Each pairs the book’s prose with a short exercise; progress is tracked locally in your browser, no account required.';
-
   const html = template
-    .replace(/{{TITLE}}/g, escapeAttr(title))
-    .replace(/{{DESCRIPTION}}/g, escapeAttr(description))
-    .replace(/{{CANONICAL_URL}}/g, SITE_URL + '/java/jbct/course/')
+    .replace(/{{TITLE}}/g, escapeAttr(course.tocTitle))
+    .replace(/{{DESCRIPTION}}/g, escapeAttr(course.tocDescription))
+    .replace(/{{CANONICAL_URL}}/g, SITE_URL + course.urlBase)
     .replace(/{{STYLE_HASH}}/g, STYLE_HASH)
-    .replace('{{INTRO}}', escapeHtml(intro))
+    .replace('{{NAV_LINKS}}', courseNavLinks(course.nav))
+    .replace(/{{REALM_HREF}}/g, course.realm.href)
+    .replace(/{{REALM_LABEL}}/g, escapeHtml(course.realm.label))
+    .replace(/{{CRUMB_LABEL}}/g, escapeHtml(course.crumbLabel))
+    .replace('{{COURSE_H1}}', course.h1)
+    .replace('{{FOOTER_LINKS}}', course.footerLinks)
+    .replace('{{INTRO}}', escapeHtml(course.tocIntro))
     .replace('{{PARTS}}', partsHtml);
 
-  writePage(path.join(DIST_DIR, 'java', 'jbct', 'course', 'index.html'), html, SITE_URL + '/java/jbct/course/');
+  writePage(path.join(DIST_DIR, ...courseOutSegs(course), 'index.html'), html, SITE_URL + course.urlBase);
 }
 
 // ---------- Lesson pages ----------
 
-function buildLessonPages(flat, courseSlugSet) {
+function buildLessonPages(course, flat) {
   const template = readTemplate('lesson');
 
   flat.forEach((lesson, i) => {
-    const chapterPath = path.join(BOOK_DIR, `${lesson.slug}.md`);
+    const chapterPath = path.join(course.bookDir, `${lesson.slug}.md`);
     if (!fs.existsSync(chapterPath)) {
-      console.warn(`  WARN: book/${lesson.slug}.md not found — skipping lesson`);
+      console.warn(`  WARN: ${course.id} book/${lesson.slug}.md not found — skipping lesson`);
       return;
     }
     const rawChapter = fs.readFileSync(chapterPath, 'utf-8');
     const { body: chapterBody } = stripFrontMatter(rawChapter);
     const { title: h1Title, body: strippedBody } = stripLeadingH1(chapterBody);
     const title = h1Title || lesson.specTitle;
-    const rewritten = rewriteBookLinks(strippedBody, courseSlugSet);
+    const rewritten = rewriteBookLinks(strippedBody, course, courseByBookDir);
     const bodyHtml = md.render(rewritten);
 
-    const layerPath = path.join(COURSE_DIR, `${lesson.slug}.md`);
+    const layerPath = path.join(course.layerDir, `${lesson.slug}.md`);
     let sections = {};
     if (fs.existsSync(layerPath)) {
       sections = parseCourseLayer(fs.readFileSync(layerPath, 'utf-8'));
     } else {
-      console.warn(`  WARN: course/jbct/${lesson.slug}.md not found — lesson rendered without course-layer blocks`);
+      console.warn(`  WARN: ${course.id} course layer ${lesson.slug}.md not found — lesson rendered without course-layer blocks`);
     }
 
     const learnBox = sections.learn
@@ -460,26 +576,33 @@ function buildLessonPages(flat, courseSlugSet) {
     <div class="body">${md.render(ex.body)}</div>
   </div>`;
     }
-    const description = sections.blurb || extractFirstParagraph(chapterBody) || `${title} — JBCT course.`;
+    const description = sections.blurb || extractFirstParagraph(chapterBody) || `${title} — ${course.titleSuffix}.`;
 
     const latticeSvg = buildLatticeSVG(lesson.partSlugs, lesson.posInPart);
 
     const prev = i > 0 ? flat[i - 1] : null;
     const next = i < flat.length - 1 ? flat[i + 1] : null;
     const prevLink = prev
-      ? `<a class="prev" href="/java/jbct/course/${prev.slug}/">&larr; ${escapeHtml(prev.specTitle)}</a>`
-      : `<a class="prev" href="/java/jbct/course/">&larr; Course contents</a>`;
+      ? `<a class="prev" href="${course.urlBase}${prev.slug}/">&larr; ${escapeHtml(prev.specTitle)}</a>`
+      : `<a class="prev" href="${course.urlBase}">&larr; Course contents</a>`;
     const nextLink = next
-      ? `<a class="next" href="/java/jbct/course/${next.slug}/">Next: ${escapeHtml(next.specTitle)} &rarr;</a>`
-      : `<a class="next" href="/java/jbct/course/">Next: Course contents &rarr;</a>`;
+      ? `<a class="next" href="${course.urlBase}${next.slug}/">Next: ${escapeHtml(next.specTitle)} &rarr;</a>`
+      : `<a class="next" href="${course.urlBase}">Next: Course contents &rarr;</a>`;
 
-    const canonicalUrl = `${SITE_URL}/java/jbct/course/${lesson.slug}/`;
+    const canonicalUrl = `${SITE_URL}${course.urlBase}${lesson.slug}/`;
 
     const html = template
-      .replace(/{{TITLE}}/g, escapeAttr(`${title} — JBCT course`))
+      .replace(/{{TITLE}}/g, escapeAttr(`${title} — ${course.titleSuffix}`))
       .replace(/{{DESCRIPTION}}/g, escapeAttr(description))
       .replace(/{{CANONICAL_URL}}/g, canonicalUrl)
       .replace(/{{STYLE_HASH}}/g, STYLE_HASH)
+      .replace(/{{COURSE_HOME}}/g, course.urlBase)
+      .replace(/{{COURSE_LABEL}}/g, course.courseLabel)
+      .replace(/{{REALM_HREF}}/g, course.realm.href)
+      .replace(/{{REALM_LABEL}}/g, escapeHtml(course.realm.label))
+      .replace(/{{PARENT_HREF}}/g, course.parent.href)
+      .replace(/{{PARENT_LABEL}}/g, escapeHtml(course.parent.label))
+      .replace(/{{STORAGE_PREFIX}}/g, course.storagePrefix)
       .replace(/{{PART_NAME}}/g, escapeHtml(lesson.partName))
       .replace('{{TITLE_TEXT}}', escapeHtml(title))
       .replace('{{LATTICE_SVG}}', latticeSvg)
@@ -494,7 +617,7 @@ function buildLessonPages(flat, courseSlugSet) {
       .replace('{{SLUG_JSON}}', JSON.stringify(lesson.slug))
       .replace('{{PART_SLUGS_JSON}}', JSON.stringify(lesson.partSlugs));
 
-    writePage(path.join(DIST_DIR, 'java', 'jbct', 'course', lesson.slug, 'index.html'), html, canonicalUrl);
+    writePage(path.join(DIST_DIR, ...courseOutSegs(course), lesson.slug, 'index.html'), html, canonicalUrl);
   });
 }
 
@@ -726,16 +849,22 @@ function build() {
   fs.rmSync(DIST_DIR, { recursive: true, force: true });
   ensureDir(DIST_DIR);
 
-  const { parts, backMatter } = parseSpine();
-  const flat = flattenSpine(parts);
-  const courseSlugSet = new Set(flat.map(l => l.slug));
-
-  console.log(`Spine: ${parts.length} parts, ${flat.length} lessons.`);
+  // Parse every course's spine first so cross-course links resolve at render time.
+  COURSES.forEach(course => {
+    course.parts = parseSpine(course);
+    course.flat = flattenSpine(course.parts);
+    course.lessonSlugSet = new Set(course.flat.map(l => l.slug));
+    console.log(`Spine (${course.id}): ${course.parts.length} parts, ${course.flat.length} lessons.`);
+  });
 
   buildFrontDoor();
   buildLandingPages();
-  buildCourseToc(parts, flat);
-  buildLessonPages(flat, courseSlugSet);
+
+  COURSES.forEach(course => {
+    buildCourseToc(course, course.parts, course.flat);
+    buildLessonPages(course, course.flat);
+  });
+
   buildLegacyPages();
   buildRedirects();
 

--- a/website/content/architecture-synthesis.md
+++ b/website/content/architecture-synthesis.md
@@ -8,4 +8,4 @@ A practicing architect can start here directly; a reader arriving from Process-F
 
 Four architectures have been derived blind, against a locked answer sheet, and graded against what those systems actually run — in the open, with the misses shown alongside the hits. The registered predictions, answer sheets, operator prompts, and grading rubrics are public in a [replication kit](https://github.com/siy/derivation-artifacts). Every derivation after the first four is registered there before its outcome is checked, and counterexamples are invited.
 
-The book — [*Architecture Synthesis: The Next Correct Step*](https://leanpub.com/architecture-synthesis-the-next-correct-step) — is on Leanpub. A course edition follows.
+The book — [*Architecture Synthesis: The Next Correct Step*](https://leanpub.com/architecture-synthesis-the-next-correct-step) — is on Leanpub. The [free course edition](/method/architecture-synthesis/course/) walks the whole derivation lesson by lesson, each paired with an exercise you run on a system you own.

--- a/website/content/pfd.md
+++ b/website/content/pfd.md
@@ -6,4 +6,4 @@ The book carries one ticketing platform from a single use case to a multi-tenant
 
 The condensed edition — the whole argument in about 25 minutes — is free. The full book is on [Leanpub](https://leanpub.com/process-first-design).
 
-A course edition is planned; this page holds its slot until then.
+The [free course edition](/method/pfd/course/) walks the whole method lesson by lesson, each paired with an exercise you run on a system you own.

--- a/website/course/architecture-synthesis/answer-sheet.md
+++ b/website/course/architecture-synthesis/answer-sheet.md
@@ -1,0 +1,14 @@
+## blurb
+Nine questions, five driver modes, and an entry gate that prices wishes before they're allowed to count as answers.
+
+## learn
+- The nine questions by driver mode (prune, select, isolate, split, bound)
+- The membership criterion — a question earns its seat by pressing an axis alone
+- The pricing drill for unpriced SLOs
+- Scope discipline: per operation, per data class, per path — never system-wide
+- The audit / replay / erasure decomposition
+- Domain-shape and change-driver facts as the second input row
+
+## exercise
+### Run the Nine Questions | ~30 min
+Pick a system you operate and answer all nine questions for it — priced, scoped, with UNKNOWN written wherever it's true. Note which answers actually press an axis and which sit inert against what the system already does. The inert ones are the interesting result.

--- a/website/course/architecture-synthesis/axes-and-ledger.md
+++ b/website/course/architecture-synthesis/axes-and-ledger.md
@@ -1,0 +1,13 @@
+## blurb
+Six axes, each value priced as provides / mechanism / always-on cost — the middle space between demands and named architecture styles.
+
+## learn
+- The three-spaces model: demand, selection, position
+- Demand shapes and the second-copy diagnostic (volume, contention, burst, deadline)
+- Containment rungs: hardware, cache, coalescing, replicas, projections
+- The six axes and their atomic values
+- The selection rule — cheapest containing value, fewest mechanisms, narrowest scope
+
+## exercise
+### Price One Axis on Your System | ~20 min
+Pick one axis and name where your system sits. Check the rung below it — would hardware sizing, caching, or coalescing contain the same demand more cheaply? If your current position costs more than the cheapest containing rung, you've found an unforced cost.

--- a/website/course/architecture-synthesis/brownfield.md
+++ b/website/course/architecture-synthesis/brownfield.md
@@ -1,0 +1,13 @@
+## blurb
+Universal Credit, the UK's welfare platform: the method run against a real inherited system, audited by a decade of public record rather than by its author.
+
+## learn
+- The audit against an inherited V0 — boundaries that predate their reasons, no blueprint, legacy welded to volatile rules
+- Reconstructing an answer sheet from the public record alone
+- The renegotiation menu history actually faced (patch, big-bang, twin-track, renegotiate the calendar)
+- Reversible-first, irreversible-late, executed by instinct rather than by method
+- The pandemic as an unrequested load test on the rebuilt vector
+
+## exercise
+### Audit a System You Inherited | ~20 min
+Pick one boundary in a system you inherited rather than built. Ask the audit's core question: what answer forces this boundary today? If the honest answer is "a contract, an org chart, or nobody remembers," you've found what the chapter calls an unforced position.

--- a/website/course/architecture-synthesis/closing.md
+++ b/website/course/architecture-synthesis/closing.md
@@ -1,0 +1,15 @@
+## blurb
+The derivative reframe, restated once more, and the book's standing invitation: run the worksheet on something real and send back what breaks it.
+
+## learn
+- The convergence claim — people keep arriving at these positions independently
+- The worksheet as the method at operating altitude
+- Design-day derivations vs. audits — audits are available immediately
+- The standing counterexample invitation
+
+## note
+The companion repository (github.com/siy/derivation-artifacts) is both the replication kit for the four blind derivations and the intake for counterexamples — a filled worksheet that the method got wrong is the most valuable thing it can receive.
+
+## exercise
+### Fill the Worksheet, End to End | ~60 min
+Take the derivation worksheet (book Appendix — The Worksheet) and fill both parts for one real system you operate: answers, pressure pass, resolved vector, verification. If the derived vector looks wrong against what you actually know, file it as a counterexample — a GitHub issue at github.com/siy/derivation-artifacts, with the sheet attached.

--- a/website/course/architecture-synthesis/derivation.md
+++ b/website/course/architecture-synthesis/derivation.md
@@ -1,0 +1,13 @@
+## blurb
+`next_step`: the procedure that turns a priced answer sheet and a ledger into a vector — null vector, prune, press, resolve, verify.
+
+## learn
+- The six steps: null vector, normalize, prune, press, resolve, verify
+- Why the null vector is a measurement precondition, not an aesthetic
+- The conflict rule — different scope splits, same scope decomposes, still-opposed halts
+- The pressure matrix as workspace and as traceability record
+- Why axis order doesn't change the outcome
+
+## exercise
+### Run the Scope Test | ~15 min
+Find two demands on a system you operate that seem to pull one axis in opposite directions. Check whether they attach to the same scope or different scopes — a path, a data class, a subsystem. If different, the axis should split, not compromise; if same, the bundle is probably under-decomposed.

--- a/website/course/architecture-synthesis/derivative.md
+++ b/website/course/architecture-synthesis/derivative.md
@@ -1,0 +1,13 @@
+## blurb
+`next_step` run against a living system, not a blank page: the audit that flags unforced positions, incremental recomputation, and merge as a first-class output.
+
+## learn
+- The audit — every position must cite the answer that forces it; silence is debt
+- Incremental recomputation — a changed row implicates only the axes it presses
+- Merge as a computed output, exactly as likely as splitting
+- Decision records with a built-in revisit trigger
+- What the derivative is not: not a prediction of what orgs build, not continuous re-architecture
+
+## exercise
+### Audit One Position | ~20 min
+Pick one architectural position in a system you operate — a split, a store, a queue — and try to name the specific answer that forces it today. If you can cite one, note it. If you can't, you've found either technical debt or a missing question on your sheet.

--- a/website/course/architecture-synthesis/derived-blind.md
+++ b/website/course/architecture-synthesis/derived-blind.md
@@ -1,0 +1,16 @@
+## blurb
+Four real systems — Stack Overflow, Shopify, Discord, a UK government registrar — derived blind from public commitments, with predictions registered before the outcomes were checked.
+
+## learn
+- The pre-registration protocol and the grade levels (A/B/C)
+- Stack Overflow — the reflex (read replicas) beaten by the answers (RAM-contained reads)
+- Shopify — cells forced by compounding blast-radius and volume demands
+- Discord — coalescing, not CQRS; the author's own prior overridden
+- Cross-findings: contention is side-symmetric, team size never presses topology
+
+## note
+The full replication kit — answer sheets, registered predictions, grading rubrics — is public at github.com/siy/derivation-artifacts. It's the open evidence behind this chapter's grades.
+
+## exercise
+### Derive a System Before You Check It | ~30 min
+Pick a system you don't control but whose commitments are public — an engineering blog, a published SLA, a scale number from a talk. Predict what its architecture forces before looking anything else up. Then check, and if you're wrong, note which answer you misread or missed.

--- a/website/course/architecture-synthesis/judgment.md
+++ b/website/course/architecture-synthesis/judgment.md
@@ -1,0 +1,12 @@
+## blurb
+The inventory of decisions the method hands back to humans — and the MTTR/MTBF debate dissolved as a worked example of where mechanization stops.
+
+## learn
+- The judgment inventory: the answers themselves, recovery ties, the renegotiation menu, the conscious second driver, enterprise-altitude inputs
+- The MTTR/MTBF trend split per failure class — degrade, compensate, design-out
+- Why means lie about incident durations the same way they lie about latency
+- The four walls of scope: enterprise backend, the socio-technical half, unpriced option value, acting on the vector
+
+## exercise
+### Find a Taste-Defended Decision | ~15 min
+Pick one architectural decision in a system you operate that gets defended by seniority or habit rather than by a cited answer. Check it against the judgment inventory — is it a genuine business preference, like a recovery tie, or is it actually mechanizable and just hasn't been priced yet?

--- a/website/course/architecture-synthesis/pathfinding.md
+++ b/website/course/architecture-synthesis/pathfinding.md
@@ -1,0 +1,14 @@
+## blurb
+Migration as pathfinding: deltas that don't commute, intermediate states with physics of their own, and six qualitative indicators that weigh a route.
+
+## learn
+- Nodes, edges, and the six edge-weight indicators (reversibility, feasibility, coupling, dual-state duration, dependency, failure amplification)
+- The three path constraints — operable, affordable, calendar-feasible
+- Non-commutativity — why the order of moves is a real decision
+- The priced scaffold — throwaway work, purchased knowingly
+- Irreversibility orders commitment — reversible steps go early
+- Migration triage: product swap, single-axis delta, compound delta
+
+## exercise
+### Grade a Migration You've Lived | ~20 min
+Take a migration you planned or executed on a system you operate. Name which of the six indicators would have killed the worse-ordered route, and check whether the actual order you took put the hard-to-reverse step as late as the dependencies allowed.

--- a/website/course/architecture-synthesis/three-profiles.md
+++ b/website/course/architecture-synthesis/three-profiles.md
@@ -1,0 +1,14 @@
+## blurb
+One domain, three answer sheets, three forced vectors — ticketing re-derived at venue, regional, and enterprise scale with every step citing its rule.
+
+## learn
+- The pressure-matrix notation, promoted from prose
+- The decomposition case — team independence vs. one deploy train
+- The rung case — read replicas vs. a separated read model
+- Audit-vs-replay disarmed by ledger comparison, not judgment
+- The scope-split case at enterprise scale
+- Contention refused correctly — a hundred-thousand-a-minute burst that moves no axis
+
+## exercise
+### Fill One Pressure-Matrix Row | ~15 min
+Take one demand from a system you operate and write it as a pressure-matrix row: scope, mode, shape, axis pressed (or inert), and the mechanism that justifies it. Cite the rule the way the chapter does — not "it depends," a named reason.

--- a/website/course/architecture-synthesis/two-teams.md
+++ b/website/course/architecture-synthesis/two-teams.md
@@ -1,0 +1,13 @@
+## blurb
+Two teams built the same ticketing product with architectures that share nothing — and neither was wrong, because both derived correctly from different answers.
+
+## learn
+- Preference wars vs. debates with a termination condition
+- The SEI gap: elicitation and evaluation, with expert judgment in between
+- The hardware-synthesis analogy — RTL then, architecture now
+- Answers in, six-axis vector out
+- The miniature derivation: a venue's ticketing system, walked axis by axis
+
+## exercise
+### Restate a Stalled Debate | ~15 min
+Recall an architecture argument at your org that never actually terminated — reconvened, restated, unresolved. Write down what unwritten answer each side was really defending, and which axis it would press. If neither side can name a number, you've found the debate's real problem.

--- a/website/course/architecture-synthesis/verification.md
+++ b/website/course/architecture-synthesis/verification.md
@@ -1,0 +1,13 @@
+## blurb
+The exit gate: the consistency lens and five rules of budget arithmetic that catch a wrong vector before anything is built.
+
+## learn
+- The consistency lens — guarantee, mechanism, behavior under failure
+- The one-bit-label ban (no system is just "highly available")
+- Latency budgets decompose downward; tails compose through the distribution
+- Envelopes compose upward by correlation; availability multiplies down a chain
+- Pre-build verification: load, capacity, failure injection
+
+## exercise
+### Fill the Consistency Lens | ~20 min
+Pick one operation in a system you operate. State its guarantee, name the mechanism that earns it, and describe its behavior under failure. Then run the arithmetic on one latency target: sum the critical path's floors and subtract from the budget. If the floor eats the budget, you've found what the lens is for.

--- a/website/course/architecture-synthesis/when-derivation-says-no.md
+++ b/website/course/architecture-synthesis/when-derivation-says-no.md
@@ -1,0 +1,12 @@
+## blurb
+Three reasonable answers on one trading platform empty an entire axis — the derivation halts, mechanically, and hands back a priced menu instead of an architecture.
+
+## learn
+- Mechanical contradiction detection — an emptied axis, no scope boundary, decomposition-stable demands
+- The renegotiation menu — which answer bends, each option priced
+- Softest-demand decomposition as the mechanical way to find the give
+- The halt inventory: infeasible intermediate, trapped state, knowledge gap, unexplored territory
+
+## exercise
+### Find the Tension in Your Own Sheet | ~15 min
+Look for two commitments in a system you operate that might genuinely conflict on one axis — not different scopes, the same one. Run the scope test on paper: do they actually share a scope, or does decomposition reveal a boundary that resolves them without a fight?

--- a/website/course/pfd/architecture-synthesis.md
+++ b/website/course/pfd/architecture-synthesis.md
@@ -1,0 +1,16 @@
+## blurb
+Where every decision the spiral deferred comes due at once - nine elicitation questions, a six-axis architecture vector, and the judgment that turns answers into a choice.
+
+## learn
+- The nine Phase-4 questions, across SLOs, constraints, operational targets, and substrate-shaping forces
+- The six-axis Phase-5 architecture vector
+- Why a hybrid vector is normal at real scale, not a compromise
+- Recovery-class selection revisited, with all four judgment considerations
+- The Phase-5/Phase-6 boundary: architectural property versus concrete technology
+
+## note
+The Architecture Synthesis course develops this into a full derivation procedure - the ledger of axis values and costs, the derivation procedure, and graded blind derivations.
+
+## exercise
+### Elicit Your Own Nine Answers | ~20 min
+Answer the nine Phase-4 questions for one subsystem you operate, even roughly - latency, availability, durability, consistency, load, constraints, release structure, cost, and multi-tenancy. Notice which axis values in your current architecture no question actually justifies.

--- a/website/course/pfd/brownfield.md
+++ b/website/course/pfd/brownfield.md
@@ -1,0 +1,13 @@
+## blurb
+The methodology run in reverse on a system nobody designed on purpose - naming what already exists before deciding what to change.
+
+## learn
+- Reverse-applying the methodology: discovering use cases from what a system actually runs
+- The Phase-4-bounded audit, scoped narrowly to the trigger that surfaced it
+- Candidate deltas judged on coherence, justification, reversibility, and composability
+- Four brownfield-specific failure modes, including services that deploy together as a monolith
+- Why a hybrid architecture is the honest working state of a living system
+
+## exercise
+### Name Your System's Current Vector | ~20 min
+Pick a system you inherited rather than designed. Name its current architecture vector as honestly as you can - deployment, substrate, storage, recovery - and identify one live question its current shape no longer answers well.

--- a/website/course/pfd/closing.md
+++ b/website/course/pfd/closing.md
@@ -1,0 +1,13 @@
+## blurb
+The book's falsifiable bet, its honest scope, and the reflexive question of what happens when you run it against your own last project.
+
+## learn
+- The bet: process-first decomposition stays cheaper to maintain than entity-first as a system grows
+- What would falsify the bet, stated plainly
+- The bounded domain - where the methodology applies, and where it doesn't
+- Five numbered predictions the book holds itself to
+- What's still open: where the six architecture axes themselves come from
+
+## exercise
+### Test the Bet on Your Last Project | ~15 min
+Take the book's bet - that process-first decomposition stays cheaper to maintain than entity-first as a system grows - to your own last project. Would the crossover already have happened by the time it mattered, or was the system still small enough that a shared model was the right call?

--- a/website/course/pfd/edge-cases.md
+++ b/website/course/pfd/edge-cases.md
@@ -1,0 +1,13 @@
+## blurb
+The methodology run against adversarial scenarios - the feature that seems to span two boundaries, the aggregate that seems to demand a rewrite.
+
+## learn
+- Altitude discovered from the change driver, never assigned to a module
+- Features that split into two honest units instead of one compromised one
+- Derived availability and owned transitions, versus stale denormalized flags
+- The change-locality-versus-aggregate argument, worked and resolved
+- Variation handled by a bound policy value, not by branching
+
+## exercise
+### Split a Two-Driver Feature | ~15 min
+Take one feature request in your system that seemed to belong to two places at once. Ask what change driver each half actually answers to, and whether the honest shape is two units rather than one awkward compromise.

--- a/website/course/pfd/foundations.md
+++ b/website/course/pfd/foundations.md
@@ -1,0 +1,16 @@
+## blurb
+The vocabulary chapter: six process properties, four value shapes, six composition patterns, and the telescope that carries them across every altitude.
+
+## learn
+- Six properties every process has: trigger, typed input, output, failures, steps, dependencies
+- Four value shapes - T, Option, Result, Promise - and when each applies
+- Six composition patterns: Leaf, Sequencer, Fork-Join, Condition, Iteration, Aspects
+- The telescope and the change-driver cohesion test
+- The recovery triple: backward recovery, forward recovery, designing failure out
+
+## note
+Dense reference chapter - most later lessons, in this course and the spiral passes, point back to a term defined here.
+
+## exercise
+### Name the Six Properties | ~15 min
+Pick one process you maintain - an endpoint, a job, a handler - and name its six properties explicitly: trigger, typed input, typed output, typed failures, steps, dependencies. Note which of the six are currently untyped or implicit in your code.

--- a/website/course/pfd/introduction.md
+++ b/website/course/pfd/introduction.md
@@ -1,0 +1,16 @@
+## blurb
+Why process, not entity, is the right unit of design, and how the book sets out to demonstrate that rather than argue it.
+
+## learn
+- Process as the unit of design, entity as the alternative it replaces
+- Independent practitioners converging on the same shape
+- The five principles the book holds itself to
+- The jigsaw-puzzle picture: local pieces, global cohesion
+- The running ticketing example and how the course reuses it
+
+## note
+No architecture decisions yet - this lesson sets the vocabulary and the running example the rest of the course builds on.
+
+## exercise
+### Find the Taste-Driven Decision | ~10 min
+Find one architecture decision in a system you maintain that was made by taste or seniority rather than derived from a requirement. Name the business fact that should have forced that decision instead, and check whether anyone could point to that fact today.

--- a/website/course/pfd/spiral-0-decisions.md
+++ b/website/course/pfd/spiral-0-decisions.md
@@ -1,0 +1,13 @@
+## blurb
+Five decisions every use case forces on its designer, before a line of code exists.
+
+## learn
+- Where a process's failures are allowed to live
+- Whether "customer" (or any shared noun) means the same thing everywhere
+- What a held reservation costs when it has to be compensated
+- How tightly a trigger couples to the business rule behind it
+- Where cross-cutting concerns get decided, not just implemented
+
+## exercise
+### Answer the Five for One Use Case | ~15 min
+Pick one use case you maintain and answer these five decisions honestly for it: where its failures live, whether its central noun means one thing everywhere it's used, what undoing it costs, how coupled its trigger is to the business rule, and where its cross-cutting concerns are decided. Note which answers were deliberate and which were accidental.

--- a/website/course/pfd/spiral-1-use-case.md
+++ b/website/course/pfd/spiral-1-use-case.md
@@ -1,0 +1,14 @@
+## blurb
+One use case, buying a ticket, walked end to end - its types, its patterns, its recovery, and the questions it deliberately leaves open.
+
+## learn
+- Per-process types versus a shared entity model
+- Value objects that genuinely mean the same thing everywhere
+- How the six patterns distribute at use-case altitude
+- Backward error recovery and designing a conflict out, in one worked example
+- Per-use-case service-level targets
+- What use-case altitude defers to later passes
+
+## exercise
+### Type One Use Case's Steps | ~20 min
+Take one use case in a system you maintain and list its steps as typed operations - trigger, typed input, typed output, typed failures. Identify one place where you currently reuse a shared entity type that should instead be a type scoped only to this use case.

--- a/website/course/pfd/spiral-2-workflow.md
+++ b/website/course/pfd/spiral-2-workflow.md
@@ -1,0 +1,13 @@
+## blurb
+Workflows emerge when use cases multiply and start sharing a change driver - compensation, saga, and time-as-decay follow from that emergence.
+
+## learn
+- Workflows as clusters of use cases sharing one change driver
+- Compensation: domain-internal versus domain-escaping, and the residue each leaves
+- Saga as a composite shape, not a primitive
+- Time-as-decay versus time-as-trigger versus time-as-condition
+- Recovery-class selection once a use case becomes a workflow
+
+## exercise
+### Classify a Workflow's Compensation | ~15 min
+Name one workflow you maintain that spans several use cases - a cancellation-and-refund path, a multi-step signup. Identify what has to be undone if it fails partway, and whether that undo stays inside your own domain or escapes into someone else's (an email, a third-party charge).

--- a/website/course/pfd/spiral-3-subsystem.md
+++ b/website/course/pfd/spiral-3-subsystem.md
@@ -1,0 +1,13 @@
+## blurb
+Subsystems emerge from workflows that change together, and business cross-cutting - the audit ledger, the compliance check - becomes a design decision instead of runtime plumbing.
+
+## learn
+- The change-driver test applied one altitude up, from workflows to subsystems
+- Thin, explicitly versioned boundary contracts between subsystems
+- Business cross-cutting versus technical cross-cutting, named as a real distinction
+- Audit-as-data versus audit-as-Aspect, and when each fits
+- Recovery-class selection when compensation has to cross a subsystem boundary
+
+## exercise
+### Locate a Boundary-Crossing Concern | ~15 min
+Pick a subsystem you own and find one business-driven concern - an audit trail, a compliance check, a cross-cutting business rule - that currently crosses its boundary. Decide whether it belongs as data your workflows produce, or as a wrapper applied uniformly around them, and say why.

--- a/website/course/pfd/spiral-4-system.md
+++ b/website/course/pfd/spiral-4-system.md
@@ -1,0 +1,13 @@
+## blurb
+The last altitude - subsystems compose into one running system, assembly separates from provisioning, and the same six patterns close the fractal.
+
+## learn
+- What rises to system level versus what stays pushed down into a subsystem
+- Assembly (wiring composition) versus provisioning (external resources), as two distinct jobs
+- Technical cross-cutting as a platform-wide, runtime-supplied property
+- The patterns completing the fractal at the fourth altitude
+- The system-level SLO as a composed, not invented, envelope
+
+## exercise
+### Separate Assembly From Provisioning | ~15 min
+In a system you operate, list what you currently wire together (assembly) separately from what you obtain from the environment (provisioning - stores, queues, external services). Note any place the two are tangled inside one mechanism, like a dependency-injection container.

--- a/website/templates/course-toc.html
+++ b/website/templates/course-toc.html
@@ -26,19 +26,15 @@
   <div class="wrap nav">
     <a class="brand" href="/">pragmatica<span>.dev</span></a>
     <nav class="links">
-      <a href="/">Start</a>
-      <a href="/method/">The Method</a>
-      <a class="current" href="/java/">The Java Realization</a>
-      <a href="/method/glossary/">Glossary</a>
-      <a href="https://github.com/pragmaticalabs/pragmatica" target="_blank" rel="noopener">GitHub</a>
+      {{NAV_LINKS}}
     </nav>
   </div>
 </header>
 
 <div class="wrap">
   <div class="page-head">
-    <div class="crumb"><a href="/java/">The Java Realization</a> / <b>JBCT course</b></div>
-    <h1 style="font-size:38px;letter-spacing:-.02em;line-height:1.15;margin:10px 0 6px">Java Backend Coding Technology &mdash; Course</h1>
+    <div class="crumb"><a href="{{REALM_HREF}}">{{REALM_LABEL}}</a> / <b>{{CRUMB_LABEL}}</b></div>
+    <h1 style="font-size:38px;letter-spacing:-.02em;line-height:1.15;margin:10px 0 6px">{{COURSE_H1}}</h1>
     <p style="color:var(--ink-soft);font-size:16px;margin-bottom:8px">{{INTRO}}</p>
   </div>
 
@@ -50,7 +46,7 @@
 <footer>
   <div class="wrap">
     <div>pragmatica.dev &mdash; the education home of the series &middot; commercial: <a href="https://pragmaticalabs.io/" target="_blank" rel="noopener">pragmaticalabs.io</a></div>
-    <div><a href="/java/jbct/reference/">API reference</a> &middot; <a href="https://leanpub.com/jbct-book" target="_blank" rel="noopener">Get the book</a> &middot; <a href="https://github.com/pragmaticalabs/pragmatica" target="_blank" rel="noopener">GitHub</a></div>
+    <div>{{FOOTER_LINKS}}<a href="https://github.com/pragmaticalabs/pragmatica" target="_blank" rel="noopener">GitHub</a></div>
   </div>
 </footer>
 

--- a/website/templates/front-door.html
+++ b/website/templates/front-door.html
@@ -74,8 +74,8 @@
 </section>
 
 <section class="entries wrap">
-  <a class="chip active" href="https://leanpub.com/process-first-design" target="_blank" rel="noopener">I design processes <small>start with Process-First Design</small></a>
-  <a class="chip" href="/method/architecture-synthesis/">I am an architect <small>start with Architecture Synthesis</small></a>
+  <a class="chip active" href="/method/pfd/course/">I design processes <small>start with Process-First Design</small></a>
+  <a class="chip" href="/method/architecture-synthesis/course/">I am an architect <small>start with Architecture Synthesis</small></a>
   <a class="chip" href="/java/jbct/course/">I write Java backends <small>start with the JBCT course</small></a>
 </section>
 
@@ -113,7 +113,7 @@
         <circle cx="36" cy="36" r="3.4" fill="#f59e0b" stroke="#1a2840" stroke-width="1.2"/></svg>
       <h3>Process-First Design</h3>
       <p>The design method: nine questions, four shapes, six altitudes.</p>
-      <div class="row"><a class="btn soon" href="/method/pfd/">Course planned</a><a class="btn book" href="https://leanpub.com/process-first-design" target="_blank" rel="noopener">Book</a></div>
+      <div class="row"><a class="btn course" href="/method/pfd/course/">Free course</a><a class="btn book" href="https://leanpub.com/process-first-design" target="_blank" rel="noopener">Book</a></div>
     </div>
     <div class="card">
       <svg width="72" height="72" viewBox="0 0 72 72"><g stroke="#1a2840" stroke-width="1.4">
@@ -124,7 +124,7 @@
         <circle cx="12" cy="32" r="3.4" fill="#f59e0b" stroke="#1a2840" stroke-width="1.2"/></svg>
       <h3>Architecture Synthesis</h3>
       <p>The next correct step: architecture derived, not chosen.</p>
-      <div class="row"><a class="btn soon" href="/method/architecture-synthesis/">Course planned</a><a class="btn book" href="https://leanpub.com/architecture-synthesis-the-next-correct-step" target="_blank" rel="noopener">Book</a></div>
+      <div class="row"><a class="btn course" href="/method/architecture-synthesis/course/">Free course</a><a class="btn book" href="https://leanpub.com/architecture-synthesis-the-next-correct-step" target="_blank" rel="noopener">Book</a></div>
     </div>
     <div class="card">
       <svg width="72" height="72" viewBox="0 0 72 72"><g stroke="#1a2840" stroke-width="1.6" fill="none">

--- a/website/templates/lesson.html
+++ b/website/templates/lesson.html
@@ -25,14 +25,14 @@
 <header>
   <div class="nav-lesson">
     <a class="brand" href="/">pragmatica<span>.dev</span></a>
-    <a class="up" href="/java/jbct/course/">JBCT course &middot; contents &uarr;</a>
+    <a class="up" href="{{COURSE_HOME}}">{{COURSE_LABEL}} &middot; contents &uarr;</a>
   </div>
 </header>
 
 <div class="wrap-narrow">
 
   <div class="lesson-head">
-    <div class="crumb"><a href="/java/">The Java Realization</a> / <a href="/java/jbct/">JBCT course</a> / <b>{{PART_NAME}}</b></div>
+    <div class="crumb"><a href="{{REALM_HREF}}">{{REALM_LABEL}}</a> / <a href="{{PARENT_HREF}}">{{PARENT_LABEL}}</a> / <b>{{PART_NAME}}</b></div>
     <h1>{{TITLE_TEXT}}</h1>
   </div>
 
@@ -68,7 +68,7 @@
 (function(){
   var SLUG = {{SLUG_JSON}};
   var PART_SLUGS = {{PART_SLUGS_JSON}};
-  var KEY_PREFIX = 'jbct:';
+  var KEY_PREFIX = '{{STORAGE_PREFIX}}';
 
   function isDone(slug) { return localStorage.getItem(KEY_PREFIX + slug) === '1'; }
 


### PR DESCRIPTION
Adds free web course editions for Process-First Design (11 lessons) and Architecture Synthesis (13 lessons), mirroring the existing JBCT course.

**Build:** `website/build.js` generalized from a single hardcoded JBCT course to a 3-course registry (`COURSES`). JBCT output is **byte-identical** except for one intentional fix (below). Templates `lesson.html`/`course-toc.html` parametrized via placeholders; front-door + method landings link the live courses.

**Lessons:** 24 thin course-layer files (blurb/learn/note/exercise) that reference book prose, never restate it (single-source guardrail). Every exercise is an apply-to-your-system drill; AS closing = fill the worksheet + counterexample intake.

**Bug fix (also fixes the live JBCT course):** `parseCourseLayer`'s `\s*$` terminator matched every line-end under `/m`, truncating every multi-line section after its first line — so the shipped JBCT course was showing only the first learn bullet, cut-off notes, and unparsed exercise headers ("Exercise — Exercise"). Fixed to capture full sections. All 22 JBCT lessons now render complete learn/note/exercise blocks.

Verification: `node build.js` clean, 68 pages, all internal links resolve; golden-diff confirms no JBCT regression beyond the intended content fix.