### PR TITLE
feat: AS derivation worksheet as a course page

### DIFF
--- a/website/build.js
+++ b/website/build.js
@@ -113,7 +113,7 @@ const COURSES = [
     tocTitle: 'Architecture Synthesis Course — pragmatica.dev',
     tocDescription: 'Architecture Synthesis, chapter by chapter: derive an architecture from service-level objectives, verify it against its own budget, and grade it against real systems. Each lesson pairs book prose with an apply-to-your-system exercise. Free, no account required.',
     tocIntro: 'The whole derivation method as a sequence of lessons. Each pairs the book’s prose with a short exercise you run on a system you own; progress is tracked locally in your browser, no account required.',
-    footerLinks: '<a href="/method/architecture-synthesis/reference/">Reference cards</a> &middot; <a href="https://leanpub.com/architecture-synthesis-the-next-correct-step" target="_blank" rel="noopener">Get the book</a> &middot; ',
+    footerLinks: '<a href="/method/architecture-synthesis/reference/">Reference cards</a> &middot; <a href="/method/architecture-synthesis/worksheet/">Worksheet</a> &middot; <a href="https://leanpub.com/architecture-synthesis-the-next-correct-step" target="_blank" rel="noopener">Get the book</a> &middot; ',
     nonLessonSlugs: new Set(['series-note', 'acknowledgments', 'appendix-worksheet', 'appendix-reference-cards', 'references'])
   }
 ];
@@ -483,6 +483,16 @@ const LANDING_PAGES = [
     related: [
       { href: '/method/architecture-synthesis/course/', label: 'Architecture Synthesis course', note: 'back to contents' },
       { href: '/method/architecture-synthesis/', label: 'Architecture Synthesis', note: 'overview' }
+    ]
+  },
+  {
+    src: 'book-arch/appendix-worksheet.md', out: 'method/architecture-synthesis/worksheet/index.html', fallbackTitle: 'The Derivation Worksheet',
+    crumb: crumbDeep([{ href: '/method/', label: 'The Method' }, { href: '/method/architecture-synthesis/course/', label: 'Architecture Synthesis course' }], 'Worksheet'),
+    nav: 'method',
+    description: 'The Architecture Synthesis derivation worksheet: the blank two-part table you fill to derive an architecture from answers and verify it against its own budget.',
+    related: [
+      { href: '/method/architecture-synthesis/course/', label: 'Architecture Synthesis course', note: 'back to contents' },
+      { href: '/method/architecture-synthesis/reference/', label: 'Reference cards', note: 'the method as a deck' }
     ]
   }
 ];

--- a/website/course/architecture-synthesis/closing.md
+++ b/website/course/architecture-synthesis/closing.md
@@ -12,4 +12,4 @@ The companion repository (github.com/siy/derivation-artifacts) is both the repli
 
 ## exercise
 ### Fill the Worksheet, End to End | ~60 min
-Take the derivation worksheet (book Appendix — The Worksheet) and fill both parts for one real system you operate: answers, pressure pass, resolved vector, verification. If the derived vector looks wrong against what you actually know, file it as a counterexample — a GitHub issue at github.com/siy/derivation-artifacts, with the sheet attached.
+Take the [derivation worksheet](/method/architecture-synthesis/worksheet/) and fill both parts for one real system you operate: answers, pressure pass, resolved vector, verification. If the derived vector looks wrong against what you actually know, file it as a counterexample — a GitHub issue at github.com/siy/derivation-artifacts, with the sheet attached.


### PR DESCRIPTION
The AS closing lesson's capstone exercise says 'fill the derivation worksheet', but course-only readers (no book) couldn't see it. Publishes the worksheet at /method/architecture-synthesis/worksheet/ (mirroring the reference-cards page), links it from the capstone exercise, and adds it to the course footer.