### PR TITLE
JBCT 4.4.0: testing pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Java sources and no `pom.xml` — the only build here is the website.
 
 | Book | Source | Version | Tag prefix |
 |------|--------|---------|------------|
-| Java Backend Coding Technology | `book/` | 4.3.1 | `jbct-v` |
+| Java Backend Coding Technology | `book/` | 4.4.0 | `jbct-v` |
 | Process-First Design | `book-pfd/` | 2.4.2 | `pfd-v` |
 | Architecture Synthesis | `book-arch/` | 1.1.2 | `arch-v` |
 | Aether | `book-aether/` | 0.1.0 (draft) | `aether-v` |

--- a/book/CHANGELOG.md
+++ b/book/CHANGELOG.md
@@ -7,6 +7,55 @@ All notable changes to the JBCT book, newest first. Format:
 Earlier history (1.x–2.x) predates per-book changelogs and lives in the
 repository root `CHANGELOG.md`.
 
+## [4.4.0] - 2026-08-05
+
+A testing pass. Every change below came from implementing the book's own testing advice
+against real code and finding where it stopped giving answers -- the same method that
+produced the *Architecture Synthesis* corrections, applied reflexively.
+
+### Added
+- **`PriceCalculator`, implemented and tested** (*PlaceOrder*): the interface was declared
+  in Step 5 and never implemented, and *Testing in Practice* named `PricingEngine` as its
+  illustration of a complex leaf without ever working one. It is now the book's worked
+  example of counting a decision space: eighteen nominal combinations, of which three are
+  structurally impossible (an order over the large-order threshold, discounted by at most
+  10%, always clears free shipping), leaving fifteen rows in a table. Paired with the one
+  test that belongs at the composition -- that the calculated total is the total actually
+  charged -- which needs an interaction assertion, because the total never appears in the
+  use case's response.
+- **An adapter contract test** (*PlaceOrder*, `InventoryChecker`): the book prescribed
+  contract tests and no worked example contained one, which left every stub in every
+  example an unverified assumption about a boundary. The third case is the load-bearing
+  one: a transport exception translated into a typed domain failure is the adapter's whole
+  job and the one thing no use case test can reach.
+- **Two rules the worked examples already followed silently** (*Testing Philosophy*).
+  *Assert on the outcome, except where the effect is invisible in it* -- a transfer that
+  retried looks identical to one that did not, which is why `TransferFunds` and
+  `PublishArticle` capture calls and the others do not. The rule is neither "avoid mocks"
+  nor "verify interactions": assert on the effect where it is visible and on the call only
+  where it is not. And *one composition test for propagation, N cheap vectors for the
+  space*, which is what `RegisterUser` has been doing by testing validation at two levels.
+
+### Changed
+- **Count decisions, not branches** (*Testing in Practice*). The "3+ branches" guideline is
+  kept -- checked against an independent JBCT-structured codebase, it predicted every
+  isolate-or-not decision correctly -- but it fails in one direction: a branch count cannot
+  see a decision expressed as *data*. A limit resolved by looking up two enumerations,
+  seven types against five tiers, is thirty-five answers wrapped in four conditionals, and
+  rates borderline by branch count while being the most combinatorial rule in the system.
+- **"100% coverage" retired as the target for value objects** (*Testing Philosophy*). Four
+  hand-picked strings reach 100% line coverage of `Email`; so would two. A metric that
+  reports the same number for a careful suite and a lucky one is measuring the paths the
+  code has, not the space it decides over. Replaced with a three-way split by space type:
+  examples where the space is small and enumerable, a table where it is a finite grid, and
+  a stated invariant where it is unbounded. Property-based testing is named as the tool
+  class for the third case and deliberately not taught; writing the invariant down is what
+  stops four examples from being mistaken for coverage of an infinite space.
+- **A branch the composition cannot reach is a design finding** (*Testing in Practice*): a
+  two-branch rule reading `Instant.now()` is not cheap-to-reach, it is unreachable, and the
+  suite silently changes its answer at the cutoff. The fix is the undeclared dependency,
+  not a unit test.
+
 ## [4.3.1] - 2026-07-24
 
 Reconciliation with the merged rc3 lint rules.

--- a/book/from-process-to-patterns.md
+++ b/book/from-process-to-patterns.md
@@ -1,6 +1,6 @@
 # From Process to Patterns
 
-**Based on:** JBCT v4.3.1 | **Pragmatica Core:** 1.0.0-rc1
+**Based on:** JBCT v4.4.0 | **Pragmatica Core:** 1.0.0-rc1
 
 ## What You'll Learn
 

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -1,6 +1,6 @@
 # Introduction - Code Unification
 
-**Based on:** JBCT v4.3.1 | **Pragmatica Core:** 1.0.0-rc1
+**Based on:** JBCT v4.4.0 | **Pragmatica Core:** 1.0.0-rc1
 
 ## About the Series
 

--- a/book/placeorder-example.md
+++ b/book/placeorder-example.md
@@ -496,15 +496,81 @@ public record PaymentConfirmation(
 
 ### PriceCalculator
 
+The only leaf in this use case with a decision space worth counting. Everything else here
+either validates one field or calls one adapter; this one combines three independent rules
+and has to resolve what happens when two of them apply at once.
+
 ```java
 package com.example.shop.usecase.placeorder;
 
 import com.example.shop.domain.shared.Money;
+import com.example.shop.domain.shared.ProductId;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/** Unit prices and product facts. Products are known to exist: CheckInventory ran first. */
+public interface PriceList {
+    Money unitPrice(ProductId productId);
+    boolean isOversized(ProductId productId);
+}
 
 public interface PriceCalculator {
     Money calculate(ValidOrderRequest request);
+
+    Money FLAT_SHIPPING      = new Money(new BigDecimal("9.99"));
+    Money OVERSIZED_SHIPPING = new Money(new BigDecimal("49.99"));
+    BigDecimal FREE_SHIPPING_THRESHOLD = new BigDecimal("500.00");
+    BigDecimal LARGE_ORDER_THRESHOLD   = new BigDecimal("1000.00");
+
+    static PriceCalculator priceCalculator(PriceList prices) {
+        return request -> {
+            var subtotal = request.lines()
+                                  .stream()
+                                  .map(line -> prices.unitPrice(line.productId())
+                                                     .multiply(line.quantity().value()))
+                                  .reduce(Money.ZERO, Money::add)
+                                  .value();
+
+            var itemCount = request.lines()
+                                   .stream()
+                                   .mapToInt(line -> line.quantity().value())
+                                   .sum();
+
+            // Rule 1: volume, by item count.
+            var volumeRate = itemCount >= 50 ? new BigDecimal("0.10")
+                           : itemCount >= 20 ? new BigDecimal("0.05")
+                           : BigDecimal.ZERO;
+
+            // Rule 2: order value.
+            var valueRate = subtotal.compareTo(LARGE_ORDER_THRESHOLD) >= 0
+                            ? new BigDecimal("0.05")
+                            : BigDecimal.ZERO;
+
+            // Rule 3: they do not stack. The customer gets the better of the two.
+            var discounted = subtotal.multiply(BigDecimal.ONE.subtract(volumeRate.max(valueRate)));
+
+            // Rule 4: shipping, decided after the discount.
+            var oversized = request.lines()
+                                   .stream()
+                                   .anyMatch(line -> prices.isOversized(line.productId()));
+            var shipping = oversized                                          ? OVERSIZED_SHIPPING.value()
+                         : discounted.compareTo(FREE_SHIPPING_THRESHOLD) >= 0 ? BigDecimal.ZERO
+                                                                              : FLAT_SHIPPING.value();
+
+            return new Money(discounted.add(shipping).setScale(2, RoundingMode.HALF_UP));
+        };
+    }
 }
 ```
+
+**Count the decisions before writing tests.** Three volume bands, two order-value bands,
+three shipping outcomes: **eighteen combinations**, and the stacking rule is only
+observable in the ones where both discounts are non-zero and unequal.
+
+That number is what decides how this leaf gets tested, and it is available before a single
+test exists. A branch count would say seven or eight; line coverage would go green well
+short of eighteen. Neither instrument sees the space.
 
 ---
 
@@ -726,6 +792,145 @@ class QuantityTest {
     }
 }
 ```
+
+### Complex Leaf Tests: the decision space
+
+`PriceCalculator` has eighteen nominal combinations. Counting them first pays off twice:
+it tells you how many vectors you need, and it tells you which cells cannot happen.
+
+**Three of the eighteen are structurally impossible.** An order of 1000 or more, after a
+discount of at most 10%, is still 900 or more, which always clears the free-shipping
+threshold. A large order can never pay flat shipping. That is not a gap in the tests; it
+is a fact about the rules, and you only see it because you counted.
+
+Fifteen remain, and they go in a table, where a missing row is a visible hole:
+
+```java
+class PriceCalculatorTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        // unit,  items, oversized, expected  -- subtotal / volume band / value band / shipping
+        "  20.00,     5, false,      109.99",  //   100 / none / low  / flat
+        "   4.00,    25, false,      104.99",  //   100 / 5%   / low  / flat
+        "   2.00,    50, false,       99.99",  //   100 / 10%  / low  / flat
+        " 120.00,     5, false,      600.00",  //   600 / none / low  / free
+        "  24.00,    25, false,      570.00",  //   600 / 5%   / low  / free
+        "  12.00,    50, false,      540.00",  //   600 / 10%  / low  / free
+        "  20.00,     5, true,       149.99",  //   100 / none / low  / oversized
+        "   4.00,    25, true,       144.99",  //   100 / 5%   / low  / oversized
+        "   2.00,    50, true,       139.99",  //   100 / 10%  / low  / oversized
+        " 200.00,     5, false,      950.00",  //  1000 / none / high / free
+        "  40.00,    25, false,      950.00",  //  1000 / 5% vs 5%: equal, so no stacking
+        "  20.00,    50, false,      900.00",  //  1000 / 10% beats 5%: volume wins
+        " 200.00,     5, true,       999.99",  //  1000 / none / high / oversized
+        "  40.00,    25, true,       999.99",  //  1000 / 5%   / high / oversized
+        "  20.00,    50, true,       949.99",  //  1000 / 10%  / high / oversized
+    })
+    void calculate_computesTotal_acrossTheDecisionSpace(BigDecimal unitPrice,
+                                                        int items,
+                                                        boolean oversized,
+                                                        BigDecimal expected) {
+        var prices = priceListOf(unitPrice, oversized);
+
+        assertEquals(expected, PriceCalculator.priceCalculator(prices)
+                                              .calculate(orderOf(items))
+                                              .value());
+    }
+
+    /** Every unit costs the same, so the subtotal is unit price times item count. */
+    static PriceList priceListOf(BigDecimal unitPrice, boolean oversized) {
+        return new PriceList() {
+            public Money unitPrice(ProductId id)  { return new Money(unitPrice); }
+            public boolean isOversized(ProductId id) { return oversized; }
+        };
+    }
+}
+```
+
+Two rows carry the stacking rule on their own: at 1000 and 25 items both discounts are 5%,
+so an implementation that added them would return 900.00 instead of 950.00. At 1000 and 60
+items the volume rule wins. Neither fact is visible from any single row.
+
+### The one test that belongs at the composition
+
+The table cannot see whether the calculated price is the price actually charged. That is a
+fact about the chain, so it needs exactly one test in `PlaceOrderTest` -- and it needs an
+**interaction assertion**, because the total does not appear in the use case's response:
+
+```java
+@Test
+void execute_chargesTheCalculatedTotal() {
+    var charged = new AtomicReference<Money>();
+
+    PlaceOrder.ProcessPayment processPayment = (reserved, total) -> {
+        charged.set(total);
+        return Promise.success(new PaymentConfirmation("tx-456", Instant.now()));
+    };
+    // The REAL PriceCalculator, over the same price list the table uses:
+    // 4.00 a unit, not oversized. Twenty-five items is 100.00, less 5% volume,
+    // plus flat shipping.
+    var priceCalculator = PriceCalculator.priceCalculator(
+        PriceCalculatorTest.priceListOf(new BigDecimal("4.00"), false));
+    // ... remaining stubs
+
+    useCase.execute(orderRequestOf(25))
+           .await()
+           .onFailure(Assertions::fail)
+           .onSuccess(_ -> assertEquals(new BigDecimal("104.99"), charged.get().value()));
+}
+```
+
+**One composition test, fifteen isolated vectors.** Run the arithmetic the other way and
+the cost is obvious: each composition vector needs six stubs, a request with lines and an
+address, and an `await()` -- roughly fourteen lines against one row in a table. Fifteen of
+those is about two hundred lines that assemble the whole use case to check a multiplication,
+and every failure reports "PlaceOrder failed" rather than naming the rule that broke.
+
+### Adapter Contract Tests
+
+Every stub above is an assumption about a boundary. `checkInventory` returning
+`Promise.success` asserts that the real `InventoryChecker` succeeds that way, and nothing
+in the use case tests checks it. **That is what adapter contract tests are for, and a suite
+without them is a suite whose stubs nobody has verified.**
+
+Adapters get success and error modes -- not thirty repetitions of the happy path:
+
+```java
+class InventoryCheckerTest {
+    @Test
+    void apply_succeeds_whenAllItemsInStock() {
+        var checker = new InventoryChecker(stockOf(PRODUCT, 10));
+
+        checker.apply(requestFor(PRODUCT, 2))
+               .await()
+               .onFailure(Assertions::fail);
+    }
+
+    @Test
+    void apply_fails_whenAnItemIsOutOfStock() {
+        var checker = new InventoryChecker(stockOf(PRODUCT, 1));
+
+        checker.apply(requestFor(PRODUCT, 2))
+               .await()
+               .onSuccess(Assertions::fail);
+    }
+
+    @Test
+    void apply_wrapsTheFailure_whenTheInventoryServiceIsDown() {
+        var checker = new InventoryChecker(failingClient(new IOException("connection reset")));
+
+        checker.apply(requestFor(PRODUCT, 2))
+               .await()
+               .onSuccess(Assertions::fail)
+               .onFailure(cause -> assertInstanceOf(OrderError.InventoryUnavailable.class, cause));
+    }
+}
+```
+
+The third one matters most: it pins the translation from an exception at the boundary to a
+typed failure inside the domain. That translation is the adapter's entire job, and it is
+the one thing no use case test can reach.
 
 ### Use Case Integration Test
 

--- a/book/testing-philosophy.md
+++ b/book/testing-philosophy.md
@@ -104,6 +104,33 @@ class EmailTest {
 
 **Why unit test here?** Value objects have zero dependencies. They're pure functions. Unit testing is natural.
 
+**But "100% coverage" is the wrong target, and the example above shows why.** Four
+hand-picked strings reach 100% line coverage of `Email`. So would two. The metric reports
+the same number for a careful suite and a lucky one, because it measures the paths the code
+has rather than the space it decides over.
+
+Count the space instead, and let it choose the shape of the tests:
+
+| The space | Write | Because |
+|---|---|---|
+| Small and enumerable (a status enum, a three-way branch) | examples | the space *is* the examples |
+| A finite grid (an enum against an enum, banded ranges) | a table -- `@ParameterizedTest` with one row per cell | the cell count is known, so a missing row is a visible hole |
+| Unbounded (any string, any `BigDecimal`, any timestamp) | state the invariant | examples sample an infinite space arbitrarily, and four are as arbitrary as one |
+
+`Email` is the third kind. Four strings do not cover the space of malformed addresses; they
+cover four of them. The honest form of the test is the property the parser guarantees --
+that normalization is idempotent, that no accepted value fails the invariant -- which is
+what the tools called *property-based testing* libraries exist to check by generating
+inputs rather than listing them. This book does not teach them, and you do not need one to
+benefit: writing down the invariant, even as a comment above four examples, is what stops
+the four from being mistaken for coverage of the space.
+
+`Quantity` (1..100) is the *first* kind wearing the clothes of the third. It has 102
+interesting values including the boundaries, and boundary examples genuinely cover it.
+
+The worked case is `PriceCalculator` in [PlaceOrder](placeorder-example.md) -- eighteen
+nominal combinations, three of them structurally impossible, fifteen rows in a table.
+
 **2. Business Leaves: Unit Tests if Complex**
 
 Simple business leaves (single calculation, simple transformation) don't need isolated tests - they're covered by use case integration tests.
@@ -151,6 +178,42 @@ class UserLoginTest {
 ```
 
 This tests **real behavior**: validation -> credentials -> status -> token, with error propagation.
+
+### Two rules the examples in this book follow
+
+Both are visible in the worked examples, and neither is obvious enough to leave unstated.
+
+**Assert on the outcome, except when the effect is invisible in it.**
+
+A stub tells you what a step returned. It does not tell you the step was called. Most of
+the time that is fine -- if the outcome is right, the steps ran. But some behavior leaves
+no trace in the response:
+
+- A transfer that retried twice looks exactly like one that never retried.
+- A transfer that wrote an audit entry looks exactly like one that dropped it.
+- An article routed to immediate publication differs from one routed to review by *which
+  step was called*, not by the value returned.
+
+There, capturing the call is the only oracle that can see the behavior under test, and
+[TransferFunds](transferfunds-example.md) and [PublishArticle](publisharticle-example.md)
+both do exactly that.
+
+Everywhere else, capturing calls couples the test to the implementation for nothing. The
+rule is not "avoid mocks" and it is not "verify interactions" -- it is **assert on the
+effect where the effect is visible, and on the call only where it is not.** That yields
+far fewer interaction assertions than a mock-first habit produces, and a firmly non-zero
+number, which a no-mocks rule gets wrong.
+
+**One composition test for propagation, N cheap vectors for the space.**
+
+[RegisterUser](registeruser-example.md) tests validation twice: directly against
+`ValidRequest`, and through `execute`. That looks like duplication and is not.
+
+The composition adds exactly one fact -- that a validation failure short-circuits the
+remaining steps -- and one test establishes it. The rest of the input space belongs where
+the vectors are cheap, which is the isolated level. Splitting them that way costs one test
+and buys the whole space; testing the space at the composition costs a full assembly per
+vector, and every failure names the use case rather than the rule.
 
 ---
 

--- a/book/testing-practice.md
+++ b/book/testing-practice.md
@@ -172,6 +172,40 @@ static Price applyTax(Price base) {
 
 **Guideline:** If leaf has 3+ branches or 20+ lines, write unit tests.
 
+**Count decisions, not branches.** The guideline is a serviceable proxy, and it fails in
+one direction: a branch count cannot see a decision expressed as *data*. A rule that
+resolves a limit by looking up two enumerations -- seven loan types against five credit
+tiers -- is thirty-five distinct answers wrapped in three or four conditionals. By branch
+count it rates borderline. By decision count it is the most combinatorial thing in the
+system.
+
+Ask instead: **how many distinct outcomes can this reach, and over what input space?** The
+number takes thirty seconds to work out, it is available before any test exists, and it
+tells you two things a branch count cannot -- how many vectors you need, and which
+combinations cannot occur at all. `PriceCalculator` in
+[PlaceOrder](placeorder-example.md) has eighteen nominal combinations, of which three are
+structurally impossible; the fifteen that remain go in a table, where a missing row is a
+hole you can see.
+
+**A branch the composition cannot reach is usually a design problem, not a testing one.**
+Occasionally a branch goes untested for a reason that is not cost. Consider a two-branch
+rule that reads the clock:
+
+```java
+// inside the use case
+var sameDay = cutoffPolicy.acceptsSameDay(Instant.now());
+```
+
+Two branches, so the guideline says skip it. But a composition test reaches exactly one of
+them, and *which* one depends on what time the suite runs. The after-hours path is not
+expensive to reach; it is unreachable, and the suite quietly changes its mind at the
+cutoff.
+
+The fix is not a unit test for a two-branch leaf. It is that the clock is an undeclared
+dependency -- and once it is a parameter like any other step, both branches are reachable
+at the composition and the guideline's original answer turns out to be right after all.
+The test you could not write is how you found the hidden dependency.
+
 **3. Use Cases: 90%+ Coverage (Integration Test Vectors)**
 
 ```java
@@ -205,6 +239,17 @@ class JooqUserRepositoryTest {
 ```
 
 **In use case tests:** Stub adapters. Don't test database interaction 30 times.
+
+**And note what that stubbing owes.** Every stub in a use case test is an *assumption about
+a boundary*: that the real adapter succeeds that way, fails that way, and translates a
+transport exception into that typed failure. Nothing in the use case tests checks any of
+it. The contract test is what makes the stub honest, and a suite of integration-first tests
+without adapter contract tests is a suite whose stubs nobody has verified.
+
+The third case above is the one that matters most, and it is the one most often missing:
+the translation from an exception at the boundary to a typed failure inside the domain is
+the adapter's entire job, and no use case test can reach it. Worked in full for
+`InventoryChecker` in [PlaceOrder](placeorder-example.md).
 
 ---
 


### PR DESCRIPTION
Every change here came from implementing the book's own testing advice against real code and finding where it stopped giving answers -- the same method that produced the *Architecture Synthesis* corrections, turned on JBCT.

## Two gaps that were defects

**No worked example contained an adapter contract test**, though the book prescribes them. That left every stub in every example an unverified assumption about a boundary. `InventoryChecker` now has one, and the third case is the load-bearing one: translating a transport exception into a typed domain failure is the adapter's whole job and the one thing no use case test can reach.

**`PriceCalculator` was declared in Step 5 and never implemented**, while *Testing in Practice* named `PricingEngine` as its illustration of a complex leaf and never worked one. Both holes close with the same example.

## Count decisions, not branches

The "3+ branches" guideline **stays**. Checked against an independent JBCT-structured codebase, it predicted every isolate-or-not decision correctly, and I am not replacing a rule that works.

But it fails in one direction: a branch count cannot see a decision expressed as *data*. A limit resolved by looking up two enumerations -- seven types against five tiers -- is thirty-five answers wrapped in four conditionals. It rates borderline by branch count while being the most combinatorial rule in the system.

The worked `PriceCalculator` demonstrates the alternative: eighteen nominal combinations, **three of them structurally impossible** (an order over the large-order threshold, discounted by at most 10%, always clears free shipping), fifteen rows in a table. Counting the space tells you how many vectors you need *and* which cells cannot occur -- neither of which a branch count reports.

## "100% coverage" retired for value objects

Four hand-picked strings reach 100% line coverage of `Email`. So would two. A metric that reports the same number for a careful suite and a lucky one is measuring the paths the code has, not the space it decides over.

Replaced with a split by space type: examples where the space is small and enumerable, a table where it is a finite grid, a stated invariant where it is unbounded. Property-based testing is **named as the tool class and deliberately not taught** -- writing the invariant down is what stops four examples being mistaken for coverage of an infinite space, and that costs no dependency.

## Two rules the examples already followed silently

- *Assert on the outcome, except where the effect is invisible in it.* A transfer that retried looks identical to one that did not, which is why `TransferFunds` and `PublishArticle` capture calls and the others do not. Neither "avoid mocks" nor "verify interactions" -- assert on the effect where it is visible, on the call only where it is not.
- *One composition test for propagation, N cheap vectors for the space.* What `RegisterUser` has been doing by testing validation at two levels, with the principle now stated.

## Also

A branch the composition cannot reach is a design finding, not a testing one: a two-branch rule reading `Instant.now()` is unreachable rather than expensive, and the suite silently changes its answer at the cutoff. Presented as a hazard to check for -- the independent codebase uses `LocalDateTime.now()` twice but never branches on it, so I cannot claim it as an observed pattern.

## Verification

- Site build green, 72 pages, links resolve, no orphans
- 134/134 tests
- `check-drift.sh` green -- it caught two stale `JBCT v4.3.1` headers on the version bump
- `sync-book-blocks.py --check` green