### PR TITLE
docs: correcting a defect is a patch, even when the defect was a prescription

### DIFF
--- a/BOOK-VERSIONING.md
+++ b/BOOK-VERSIONING.md
@@ -28,6 +28,16 @@ For a book, SemVer reads as:
 - **MINOR** — substantial additive change: a new chapter, section, or concept.
 - **PATCH** — corrections: typos, clarifications, fixes that add no new concept.
 
+**Correcting a defect is a PATCH, even when the defect was a prescription.** MAJOR's "content
+readers relied on" means content the book still stands behind and chose to replace, which is why
+that line is scoped to a new edition. Removing a claim the book had already contradicted
+elsewhere, or that was never true, changes no teaching and introduces no concept. The precedent is
+in *PFD*'s own history: the locking → guarded-field correction replaced a prescription readers had
+followed and shipped as **2.4.2**. It was cited later among the changes that made 3.0.0 an edition,
+but on its own it was a patch, and the edition's majorness came from the accumulation and the new
+module. (Owner ruling, 2026-09-05, after a session read that citation backwards and classified a
+set of pure corrections as majors.)
+
 ## Release status is the major version
 
 - `0.x` — pre-GA: draft / preview, not yet released to readers as a finished

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Zone verb vocabulary** (`skills/jbct/SKILL.md`) — the skill pointed at the book for the full tables and carried a divergent verb list of its own; the tables are now generated from `book/basic-patterns.md`.
 
 ### Fixed
+- **`BOOK-VERSIONING.md` says what a defect correction costs** — MAJOR's "content readers relied on being
+  removed or replaced" could be read to cover any corrected prescription, which is how the 2026-09-05 review
+  corrections were first misclassified as two paired majors. The clause now states that correcting a defect is
+  a PATCH even when the defect was a prescription, and cites *PFD*'s own precedent: the locking → guarded-field
+  correction replaced a prescription readers had followed and shipped as 2.4.2. Owner ruling, 2026-09-05.
+
 - **The site's evidence claim now matches the book's own grading** (`website/templates/front-door.html`,
   `website/content/architecture-synthesis.md`) — both said four architectures were "derived blind", while
   *Architecture Synthesis* grades those same four runs itself: one executed by operators quarantined from the


### PR DESCRIPTION
Owner ruling, 2026-09-05: the corrections in #62 are patch releases (JBCT 5.0.1, PFD 3.0.1, AS 1.1.3), or minor at the very most.

I had classified them as majors. That was wrong against the document, which defines PATCH as "corrections: typos, clarifications, fixes that add no new concept" — exactly what those were, since the books already carried the correct rule in both major cases. It was also wrong against the precedent I cited: PFD's locking → guarded-field correction replaced a prescription readers had followed and shipped as **2.4.2**, and was only cited later among the changes that made 3.0.0 an edition.

This records the disambiguation in the file that governs it, so the citation cannot be read backwards again.