### PR TITLE
fix: changelogs state the site review's provenance as known, not as external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *Architecture Synthesis* grades those same four runs itself: one executed by operators quarantined from the
   outcome, two registered in advance by an operator who was not, and one drawn from memory of the same public
   sources it would be graded against. The book was more careful than the pages selling it. Both now state the
-  protocol and the unequal insulation. Reported by an external review of the site, 2026-09-05.
+  protocol and the unequal insulation. Reported by a review of the site handed to this session, 2026-09-05.
 - **`/method/` stopped saying the free courses are planned** (`website/content/method.md`) — both course
   editions have been live and linked from the front door for weeks; the hub page still told readers to buy the
   book "until each one is built". It now links them. Same review; also recorded in the roadmap-conference

--- a/book-arch/CHANGELOG.md
+++ b/book-arch/CHANGELOG.md
@@ -10,8 +10,8 @@ what the build stamps on the PDF (single source of truth).
   a faithful design-time preview" while this book supersedes its answer sheet; the module also taught that
   the selection step could not be a procedure, which this book's derivation falsifies. The note now says the
   module previews the inputs, the axes and the considerations and points here for the procedure that
-  consumes them. Reported by an external review of the site, 2026-09-05; the PFD module was corrected in the
-  same pass.
+  consumes them. Reported by a review of the site handed to this session, 2026-09-05; the PFD module was corrected
+  in the same pass.
 
 ## [1.1.2] — 2026-08-03
 

--- a/book-pfd/CHANGELOG.md
+++ b/book-pfd/CHANGELOG.md
@@ -18,7 +18,7 @@ readers, and `1.x` are its maintenance and expansion releases.
   conflict rule, and a halt on contradiction. The section now records that both objections were right about
   those two instruments and wrong about the conclusion, states that the book is authoritative where the two
   differ, and keeps the three profiles and the named considerations as the preview and intuition they are.
-  Reported by an external review of the site, 2026-09-05.
+  Reported by a review of the site handed to this session, 2026-09-05.
 - **Semantic independence distinguished from physical contention** (*Glossary*, *The Data Question*). The
   shared-primitive entry said two processes writing different fields of one row "are not coupled by
   co-location", and the conflict table answered write-write on different fields with "no conflict to

--- a/book/CHANGELOG.md
+++ b/book/CHANGELOG.md
@@ -16,8 +16,8 @@ repository root `CHANGELOG.md`.
   objects and complex leaves and 90%+ for use cases, in its section headings, its two rationale paragraphs
   and its key takeaways. Both chapters now name the obligation instead of a percentage: the decision space
   for value objects, the deciding branches for complex leaves, and the four composition obligations for use
-  cases, which the practice chapter already carried in its own table. Reported by an external review of the
-  site, 2026-09-05; both chapters render as course lessons, so the contradiction was live on pragmatica.dev.
+  cases, which the practice chapter already carried in its own table. Reported by a review of the site handed to
+  this session, 2026-09-05; both chapters render as course lessons, so the contradiction was live on pragmatica.dev.
 - **"Exactly one of four types" restated as four semantic shapes** (*The Four Return Types*). The chapter
   opened with "exactly one of four types. Not 'usually' or 'preferably'—exactly one, always" and later
   permitted `Result<Option<T>>` and `Promise<Option<T>>` and gave `void` a defined role at the edges. The


### PR DESCRIPTION
Four changelog entries from #62 credit "an external review of the site, 2026-09-05". I do not know that. The review reached this session as text handed to it; I never established who wrote it, and I inferred "external" from its framing.

The phrase already has an established meaning in this repository — `book-pfd/CHANGELOG.md` uses it for Denys Poltorak's full read — so it reads as a named outside human, which is a stronger claim than the evidence supports. It is also live on pragmatica.dev/changelog.

Replaced with "a review of the site handed to this session", which is true under any answer. If the author was in fact an outside contributor, that is worth stating precisely and by name, and it would be the project's first such contribution; that is the owner's to confirm.

Touches `CHANGELOG.md`, which #63 also edits; rebase whichever merges second.