### PR TITLE
fix: aether article states the canary mechanism and current deploy commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   corrections were first misclassified as two paired majors. The clause now states that correcting a defect is
   a PATCH even when the defect was a prescription, and cites *PFD*'s own precedent: the locking → guarded-field
   correction replaced a prescription readers had followed and shipped as 2.4.2. Owner ruling, 2026-09-05.
+- **A published article claimed an upgrade capability the runtime does not provide, and named commands that no
+  longer exist** (`articles/aether-let-java-be-java.md`, `articles/jbct-aether-series/00-aether-let-java-be-java.md`)
+  — *Pragmatica Aether: Let Java Be Java*, live on the site and dev.to since 2026-02-13, printed four
+  `aether update` commands and promised "instant rollback with one command" with traffic that "immediately shifts
+  back". The commands were real when the article was published; pragmatica's changelog records `aether update`
+  being replaced by `aether deploy --canary` and then removed, and the command appears nowhere in `aether/docs`,
+  so only the article carried it. The passage now uses the `aether deploy` forms, replaces the instant-rollback
+  sentences with the mechanism the Aether maintainer verified at source (per-node weighted selection over the
+  endpoints each node currently knows, not atomic across the cluster and not instantaneous), states as unverified
+  whether traffic then divides in the requested proportion, and cites pragmatica#291 for the rolling-update API
+  not existing server-side. A dated note records what changed underneath the section, because nothing was wrong
+  when written. Verifiers: the Aether maintainer for the mechanism and the ticket; this session for the changelog
+  removal notice, the `DeployCommand` surface, and the docs being clean. The dev.to copy (3254469) is corrected by
+  `PUT`; the Medium copy exists and can only be edited by hand.
 
 - **The site's evidence claim now matches the book's own grading** (`website/templates/front-door.html`,
   `website/content/architecture-synthesis.md`) — both said four architectures were "derived blind", while

--- a/articles/aether-let-java-be-java.md
+++ b/articles/aether-let-java-be-java.md
@@ -98,16 +98,19 @@ Leader failover is consensus-based and near-instant. Node replacement happens au
 
 When a node fails, the recovery is automatic. Requests to slices on the failed node are immediately retried on healthy nodes. A replacement node is provisioned. It connects to peers, restores consensus state from a cluster snapshot, re-resolves artifacts from the DHT, and re-activates assigned slices. Dead nodes are automatically removed from routing tables. The new leader reconciles stale state. No human intervention required.
 
-Rolling updates leverage this fault tolerance for zero-downtime deployments with weighted traffic routing:
+Canary deployment leverages this fault tolerance to bring a new version in gradually, with an operator-settable traffic split:
 
 ```bash
-aether update start org.example:order-processor 2.0.0 -n 3
-aether update routing <id> -r 1:3    # 25% to v2, 75% to v1
-aether update routing <id> -r 1:1    # 50/50
-aether update complete <id>          # 100% to v2, drain v1
+aether deploy org.example:order-processor 2.0.0 --canary --traffic 25 -n 3
+aether deploy promote <id> --traffic 50
+aether deploy complete <id>          # 100% to v2, drain v1
 ```
 
-Deploy during business hours. Shift traffic gradually — 10% canary, then 25%, 50%, 75%, 100%. Monitor health metrics at each step. If health degrades — error rate exceeds thresholds, latency spikes — instant rollback with one command: `aether update rollback <id>`. Traffic immediately shifts back to the old version. The 3 AM pager alert becomes an audit log entry.
+Deploy during business hours. The first slice of traffic is 5% unless `--traffic` says otherwise; widen it with `promote` and watch it with `aether deploy status <id>`. If health degrades, `aether deploy rollback <id>` re-weights toward the previous version; requests already dispatched are unaffected.
+
+The split is worth stating precisely, because "shift 25% of traffic" sounds more exact than what any cluster can do. It is per-node weighted selection over the endpoints that node currently knows, so a traffic change takes effect on each node as it observes the change. It is not atomic across the cluster and not instantaneous. Whether traffic then divides in the requested proportion is unverified: the mechanism is in the source, and no end-to-end test demonstrates the proportion. `--blue-green` and `--rolling` are the other two strategies, and the rolling one is a flag ahead of its server: the rolling-update API does not exist server-side ([#291](https://github.com/pragmaticalabs/pragmatica/issues/291)). Canary is the path this section describes.
+
+*Corrected 2026-09-05. This section was written against `aether update`, a real command at publication that the CLI later consolidated into `aether deploy --canary`; the guarantee sentence above replaces "instant rollback" and "traffic immediately shifts back", which claimed more than the mechanism provides. Mechanism verified at source by the Aether maintainer.*
 
 ## For Every Project: Legacy, Greenfield, And Everything Between
 

--- a/articles/jbct-aether-series/00-aether-let-java-be-java.md
+++ b/articles/jbct-aether-series/00-aether-let-java-be-java.md
@@ -99,16 +99,19 @@ Leader failover is consensus-based and near-instant. Node replacement happens au
 
 When a node fails, the recovery is automatic. Requests to slices on the failed node are immediately retried on healthy nodes. A replacement node is provisioned. It connects to peers, restores consensus state from a cluster snapshot, re-resolves artifacts from the DHT, and re-activates assigned slices. Dead nodes are automatically removed from routing tables. The new leader reconciles stale state. No human intervention required.
 
-Rolling updates leverage this fault tolerance for zero-downtime deployments with weighted traffic routing:
+Canary deployment leverages this fault tolerance to bring a new version in gradually, with an operator-settable traffic split:
 
 ```bash
-aether update start org.example:order-processor 2.0.0 -n 3
-aether update routing <id> -r 1:3    # 25% to v2, 75% to v1
-aether update routing <id> -r 1:1    # 50/50
-aether update complete <id>          # 100% to v2, drain v1
+aether deploy org.example:order-processor 2.0.0 --canary --traffic 25 -n 3
+aether deploy promote <id> --traffic 50
+aether deploy complete <id>          # 100% to v2, drain v1
 ```
 
-Deploy during business hours. Shift traffic gradually — 10% canary, then 25%, 50%, 75%, 100%. Monitor health metrics at each step. If health degrades — error rate exceeds thresholds, latency spikes — instant rollback with one command: `aether update rollback <id>`. Traffic immediately shifts back to the old version. The 3 AM pager alert becomes an audit log entry.
+Deploy during business hours. The first slice of traffic is 5% unless `--traffic` says otherwise; widen it with `promote` and watch it with `aether deploy status <id>`. If health degrades, `aether deploy rollback <id>` re-weights toward the previous version; requests already dispatched are unaffected.
+
+The split is worth stating precisely, because "shift 25% of traffic" sounds more exact than what any cluster can do. It is per-node weighted selection over the endpoints that node currently knows, so a traffic change takes effect on each node as it observes the change. It is not atomic across the cluster and not instantaneous. Whether traffic then divides in the requested proportion is unverified: the mechanism is in the source, and no end-to-end test demonstrates the proportion. `--blue-green` and `--rolling` are the other two strategies, and the rolling one is a flag ahead of its server: the rolling-update API does not exist server-side ([#291](https://github.com/pragmaticalabs/pragmatica/issues/291)). Canary is the path this section describes.
+
+*Corrected 2026-09-05. This section was written against `aether update`, a real command at publication that the CLI later consolidated into `aether deploy --canary`; the guarantee sentence above replaces "instant rollback" and "traffic immediately shifts back", which claimed more than the mechanism provides. Mechanism verified at source by the Aether maintainer.*
 
 ## For Every Project: Legacy, Greenfield, And Everything Between
 


### PR DESCRIPTION
*Pragmatica Aether: Let Java Be Java* has been live since 2026-02-13 printing four `aether update` commands and promising "instant rollback with one command", with traffic that "immediately shifts back to the old version".

**Nothing was wrong when it was written.** `aether update` was a real command; pragmatica's changelog records it being replaced by `aether deploy --canary` and then removed, and it appears nowhere in `aether/docs` — only this article carried it. The claim rotted underneath the article for seven months.

**What changed**
- The four commands become the `aether deploy` forms (`--canary --traffic`, `promote --traffic`, `rollback`, `complete`).
- "Instant rollback" and "immediately shifts back" are replaced by the mechanism the Aether maintainer verified at source: per-node weighted selection over the endpoints each node currently knows, so a change takes effect on each node as it observes it, not atomic across the cluster and not instantaneous.
- Whether traffic then divides in the requested proportion is stated as **unverified** — the mechanism is in the source, no end-to-end test demonstrates the proportion.
- `--rolling` is named as a flag ahead of its server, citing pragmatica#291 (open: the rolling-update API does not exist server-side).
- A dated note records what changed underneath the section.

**Verification.** Mechanism and ticket: the Aether maintainer. Changelog removal notice, `DeployCommand` flags and subcommands, and `aether update` absent from `aether/docs`: this session, at source.

**Other surfaces.** dev.to 3254469 corrected by `PUT` alongside this. The Medium copy exists and cannot be reached by our tooling; it needs a manual edit by whoever holds the account.

Touches `CHANGELOG.md`, which #63 and #64 also edit; rebase whichever merges last. Build green, 89 pages.