### PR TITLE
docs/test: the JBCT structure article's evidence — illustration, pre-registration, regeneration results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Zone verb vocabulary** (`skills/jbct/SKILL.md`) — the skill pointed at the book for the full tables and carried a divergent verb list of its own; the tables are now generated from `book/basic-patterns.md`.
 
 ### Fixed
+- **The telescope rule reaches the skill, and the sync learned to rewrite book links** (`ai-tools/sync-book-blocks.py`,
+  `ai-tools/skills/jbct/project-structure/organization.md`) — the JBCT skill carried **no statement of the telescope
+  rule at all**, while `sync-book-blocks.py` pulled import ordering and member ordering from the same book chapter and
+  left *The Telescope Rule: How Structure Grows* unsynced. Found by the regeneration run, where an isolated builder
+  produced a correct flat placement without ever being given the rule. The block is now book-owned and synced (83
+  lines). Around it, the skill states when the rule fires: **placement present in the input makes the package path
+  derived, not chosen** — applied in the build phase before the first file, verified in the verification phase as an
+  explicit step that names which level came from which fact. Recorded there too is why this is a skill obligation and
+  not a lint rule: the package path is the only record in the codebase of which use cases cohere under which change
+  driver, so a checker has one side of the comparison and not two, and no rule among the 77 attempts it.
+  The sync now rewrites book-relative chapter links to their published URLs, since a skill installed under
+  `~/.claude/skills/` can reach no relative path into the book — the first synced block containing such a link
+  exposed the gap, and `check-drift.sh` already enforced the same rule on hand-written skill text.
+
 - **`BOOK-VERSIONING.md` says what a defect correction costs** — MAJOR's "content readers relied on being
   removed or replaced" could be read to cover any corrected prescription, which is how the 2026-09-05 review
   corrections were first misclassified as two paired majors. The clause now states that correcting a defect is

--- a/ai-tools/skills/jbct/project-structure/organization.md
+++ b/ai-tools/skills/jbct/project-structure/organization.md
@@ -36,6 +36,109 @@ com.example.app/
         └── EmailServiceAdapter.java
 ```
 
+## The Telescope Rule
+
+**When this rule fires.** Whenever the input carries placement information, the package path is *derived*,
+not chosen. Placement information is present when the input names subsystems or workflows, describes a
+process grouping, or when the codebase already has a package tree with sibling use cases. In that case:
+
+- **Build phase** — derive the package path from the telescope before writing the first file. A use case
+  with no siblings sits flat; a workflow package exists only where several use cases cohere under one
+  change driver; a subsystem exists only where workflows cluster. Do not invent a level the input does not
+  support, and do not omit one it does.
+- **Verification phase** — check the path you produced back against that same input, as an explicit step.
+  State the derivation: which level came from which fact.
+
+**Why it is a skill obligation and not a lint rule.** The package path is the only record in the codebase of
+which use cases cohere under which change driver. A checker compares two things; here the code holds one.
+`jbct lint` therefore cannot verify placement and no rule in it tries — the ARCH family checks dependency
+direction, the lift zone, use-case coupling and slice internals, none of which is placement. Authoring time
+is the only moment when both the requirements and the code are in hand, which makes this check yours.
+
+<!-- book:telescope-rule -->
+The layout above is a snapshot, not a starting point. A new codebase has no workflows or subsystems yet - only use cases, sitting flat. Structure is not designed up front; it **grows as the design discovers it**, and the package tree grows with it. JBCT calls this the **telescope rule**: the same altitudes that organize the design - use case, workflow, subsystem, system ([From Process to Patterns](https://pragmatica.dev/java/jbct/course/from-process-to-patterns/)) - organize the packages. As the design discovers a higher altitude, a package level **telescopes open** to hold it.
+
+The rule is mechanical, which is the point: placement stops being a matter of taste.
+
+**A new app is flat.** Every use case is a package directly under `usecase`; the only shared package is the system-wide `domain.shared`. This is the structure shown above.
+
+```
+com.example.app/
+|-- usecase/
+|   |-- holdseat/
+|   |-- confirmseat/
+|   |-- releaseexpiredholds/
+|   |-- searchevents/
+|-- domain/shared/
+```
+
+**A workflow appears, and the tree expands.** When several use cases cohere under one change driver - a reservation policy governing hold, confirm, and release - a workflow package appears and those use cases **move under it**. A level that did not exist now sits between `usecase` and the slices it groups.
+
+```
+com.example.app/
+|-- usecase/
+|   |-- reservation/                # workflow package (appeared)
+|   |   |-- holdseat/               # use cases moved under it
+|   |   |-- confirmseat/
+|   |   |-- releaseexpiredholds/
+|   |   |-- shared/                 # shared *within* reservation
+|   |-- searchevents/               # still flat - in no workflow yet
+|-- domain/shared/                  # shared across everything
+```
+
+**A subsystem appears, and it expands again.** When workflows cluster under a domain concern - booking, pricing - a subsystem package appears and the workflows move under it.
+
+```
+com.example.app/
+|-- booking/                        # subsystem package (appeared)
+|   |-- reservation/                # workflow
+|   |   |-- holdseat/
+|   |   |-- confirmseat/
+|   |   |-- releaseexpiredholds/
+|   |   |-- shared/                 # shared within reservation
+|   |-- checkout/                   # another workflow in booking
+|   |   |-- ...
+|   |-- shared/                     # shared across the booking subsystem
+|-- pricing/                        # another subsystem
+|-- domain/shared/                  # shared across everything (system altitude)
+```
+
+The same move, one altitude up; a **system** boundary does it once more - when two products or bounded contexts must coexist, subsystems group under a system module and one more level telescopes open, with `domain.shared` as its root. Each level appears only when something earns it: one use case is not a workflow, one workflow is not a subsystem. Do not create empty levels in anticipation.
+
+### Shared code lives at the lowest common ancestor
+
+This generalizes a rule you already know - *move a reused element to the nearest `shared` package* ([Null Policy & Error Recovery](https://pragmatica.dev/java/jbct/course/null-policy-recovery/)) - now that there is more than one altitude to be near. **The nearest shared package is the lowest common ancestor of the element's users.**
+
+- Used by two use cases in one workflow → that workflow's `shared`.
+- Used across two workflows in a subsystem → that subsystem's `shared`.
+- Used across subsystems → `domain.shared` at the root.
+
+`domain.shared` is simply the top of this hierarchy - the system-altitude shared package - and the tiered placement (`domain/<module>/` then `domain/shared/`) is this same rule seen at two levels. Shared code **floats up, never down**: when a new user appears at a higher altitude, lift the element to the new lowest common ancestor; never push it down speculatively, and never park it in `domain.shared` "just in case." Promote on a shared *change driver*, never on resemblance: code that merely looks alike but answers to different drivers belongs apart, not in `shared` (see [From Process to Patterns](https://pragmatica.dev/java/jbct/course/from-process-to-patterns/)).
+
+**The altitude of a shared element measures the blast radius of changing it.** Something that had to climb to `domain.shared` is reachable by the whole system; something in a workflow's `shared` is reachable by that workflow alone. Where shared code sits tells you how far a change to it can travel.
+
+**Worked example: a workflow's state machine.** When a workflow's use cases are transitions of a shared state machine (free -> held -> confirmed), the machine is shared logic - the state type and its legal transitions, used by every transition use case. Its users are those use cases, so its lowest common ancestor is the workflow package: the machine lives in that package's `shared`, and the use cases depend *up* on it, never sideways into one another.
+
+This is the case where sharing is not premature. The minimal-sharing rule guards against *accidental* sharing; a state machine is *essential* coupling - the transitions are bound by the domain itself (a seat cannot be confirmed before it is held), so representing that bond once, in one shared machine, is correct. Not sharing it would only duplicate the machine across the use cases, where the copies drift. This is the cohesion test of [From Process to Patterns](https://pragmatica.dev/java/jbct/course/from-process-to-patterns/) seen in the package tree: the transitions share one change driver - the machine's rules - so they belong together; here the rule is just where that shared logic goes.
+
+**A materialized workflow lives at its workflow package.** When a workflow earns a trigger of its own ([From Process to Patterns](https://pragmatica.dev/java/jbct/course/from-process-to-patterns/)) - a schedule, an event, an orchestration call - it becomes a slice at the workflow level (`reservation/settleholds/`, beside the use cases it composes), and its factory depends on those use cases as its steps. It is a Leaf to the subsystem above, exactly as a use case is a Leaf to its workflow. Composing its own use cases is ownership, not the sideways dependency the next rule forbids.
+
+### Dependencies point up the telescope
+
+The existing dependency rules still hold (use cases depend on shared domain code; adapters depend on use cases; never the reverse). The telescope adds one:
+
+**Dependencies point up the tree, never sideways.** A use case may depend on shared code at its own altitude or any ancestor's. It must **not** import from a sibling workflow's package. Two workflows that need each other interact through a use case or step interface at their common ancestor - not by reaching into one another's slices. An import that crosses sideways between workflow packages is a visible smell: the telescope makes the wrong dependency wrong on sight.
+
+### The reorg is a deliberate refactor
+
+Expanding a level moves files - imports change, git records the move, parallel branches may conflict on moved files. Do the move **when the workflow is confirmed**, not on a hunch: reactively, the way the design discovers the altitude, never speculatively. It is cheap with an IDE's package-move refactor, but it is not free; batch it as one commit.
+
+**Why this matters (by criteria):**
+- **Mental Overhead**: placement becomes an algorithm - lowest common ancestor - not a judgment call (+3)
+- **Complexity**: sideways coupling between features surfaces as a sideways import (+2)
+- **Business/Technical Ratio**: the package tree mirrors the business hierarchy at every altitude (+2)
+<!-- /book:telescope-rule -->
+
 ## Placement Rules
 
 ### Value Objects

--- a/ai-tools/sync-book-blocks.py
+++ b/ai-tools/sync-book-blocks.py
@@ -25,6 +25,12 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 # Destinations must contain matching <!-- book:<id> --> / <!-- /book:<id> --> markers.
 BLOCKS = [
     {
+        'id': 'telescope-rule',
+        'source': '../book/project-structure.md',
+        'heading': '## The Telescope Rule: How Structure Grows',
+        'dest': 'skills/jbct/project-structure/organization.md',
+    },
+    {
         'id': 'import-ordering',
         'source': '../book/project-structure.md',
         'heading': '### Import Ordering',
@@ -63,6 +69,27 @@ BLOCKS = [
 ]
 
 
+# A skill is installed to ~/.claude/skills/<name>/, where no relative path reaches the
+# book. Book-relative chapter links inside a synced block must therefore become web URLs;
+# check-drift.sh enforces the same rule on hand-written skill text.
+WEB_FOR_BOOK = {
+    'book': 'https://pragmatica.dev/java/jbct/course/',
+    'book-pfd': 'https://pragmatica.dev/method/pfd/course/',
+    'book-arch': 'https://pragmatica.dev/method/architecture-synthesis/course/',
+}
+
+
+def rewrite_book_links(body, source_path):
+    """Turn `](chapter.md)` / `](chapter.md#anchor)` into the chapter's published URL."""
+    book_dir = os.path.basename(os.path.dirname(os.path.normpath(source_path)))
+    base = WEB_FOR_BOOK.get(book_dir)
+    if base is None:
+        return body
+    return re.sub(r'\]\(([A-Za-z0-9._-]+)\.md(#[^)]*)?\)',
+                  lambda m: ']({}{}/{})'.format(base, m.group(1), m.group(2) or ''),
+                  body)
+
+
 def extract(source_path, heading):
     """Return the body of `heading` — everything up to the next heading of the same
     or higher level, minus trailing rules and blank lines."""
@@ -91,7 +118,7 @@ def extract(source_path, heading):
         body.pop()
     while body and not body[0].strip():
         body.pop(0)
-    return '\n'.join(body)
+    return rewrite_book_links('\n'.join(body), source_path)
 
 
 def apply_block(dest_path, block_id, body, write):

--- a/articles/assets/jbct-structure-dag.svg
+++ b/articles/assets/jbct-structure-dag.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" width="900" height="560" font-family="ui-sans-serif, system-ui, -apple-system, Helvetica, Arial, sans-serif">
+<defs><marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#374151"/></marker></defs>
+<rect width="900" height="560" fill="#ffffff"/>
+<text x="200" y="40" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">use case · Sequencer</text>
+<text x="392.5" y="40" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">orchestration</text>
+<text x="655.0" y="40" text-anchor="middle" font-size="13" font-weight="600" fill="#374151">leaves</text>
+<line x1="560" y1="52" x2="560" y2="520" stroke="#d1d5db" stroke-width="1" stroke-dasharray="4 4"/>
+<text x="552" y="535" text-anchor="end" font-size="11" font-style="italic" fill="#6b7280">routing only</text>
+<text x="568" y="535" font-size="11" font-style="italic" fill="#6b7280">all the work</text>
+<path d="M350 164 C465.0 164, 465.0 122, 580 122" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M350 164 C465.0 164, 465.0 164, 580 164" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M350 164 C465.0 164, 465.0 206, 580 206" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M475 269 C527.5 269, 527.5 248, 580 248" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M475 269 C527.5 269, 527.5 290, 580 290" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M350 300 C402.5 300, 402.5 269, 455 269" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M350 300 C465.0 300, 465.0 332, 580 332" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M475 395 C527.5 395, 527.5 374, 580 374" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M475 395 C527.5 395, 527.5 416, 580 416" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M350 395 C402.5 395, 402.5 395, 455 395" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M206 80 C393.0 80, 393.0 80, 580 80" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M206 164 C258.0 164, 258.0 164, 310 164" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M206 300 C258.0 300, 258.0 300, 310 300" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M206 395 C258.0 395, 258.0 395, 310 395" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M206 458 C393.0 458, 393.0 458, 580 458" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<path d="M206 500 C393.0 500, 393.0 500, 580 500" fill="none" stroke="#6b7280" stroke-width="1.5"/>
+<line x1="200" y1="80" x2="200" y2="500" stroke="#374151" stroke-width="2"/>
+<circle cx="200" cy="80" r="5" fill="#fff" stroke="#374151" stroke-width="2"/>
+<text x="212" y="96" font-size="12" fill="#374151">validate</text>
+<circle cx="200" cy="164" r="5" fill="#fff" stroke="#374151" stroke-width="2"/>
+<text x="212" y="180" font-size="12" fill="#374151">check availability</text>
+<circle cx="200" cy="300" r="5" fill="#fff" stroke="#374151" stroke-width="2"/>
+<text x="212" y="316" font-size="12" fill="#374151">price</text>
+<circle cx="200" cy="395" r="5" fill="#fff" stroke="#374151" stroke-width="2"/>
+<text x="212" y="411" font-size="12" fill="#374151">reserve stock</text>
+<circle cx="200" cy="458" r="5" fill="#fff" stroke="#374151" stroke-width="2"/>
+<text x="212" y="474" font-size="12" fill="#374151">save order</text>
+<circle cx="200" cy="500" r="5" fill="#fff" stroke="#374151" stroke-width="2"/>
+<text x="212" y="516" font-size="12" fill="#374151">publish</text>
+<line x1="112" y1="80" x2="193" y2="80" stroke="#374151" stroke-width="2" marker-end="url(#ar)"/>
+<text x="188" y="68" text-anchor="end" font-size="12" font-family="ui-monospace, Menlo, monospace" fill="#374151">PlaceOrderRequest</text>
+<line x1="193" y1="500" x2="112" y2="500" stroke="#374151" stroke-width="2" marker-end="url(#ar)"/>
+<text x="188" y="488" text-anchor="end" font-size="12" font-family="ui-monospace, Menlo, monospace" fill="#374151">Promise&lt;OrderPlaced&gt;</text>
+<rect x="310" y="154" width="40" height="20" rx="5" fill="#fff" stroke="#374151" stroke-width="1.5"/>
+<text x="330" y="168" text-anchor="middle" font-size="10.5" font-weight="600" fill="#374151">all</text>
+<rect x="435" y="259" width="40" height="20" rx="5" fill="#fff" stroke="#374151" stroke-width="1.5"/>
+<text x="455" y="273" text-anchor="middle" font-size="10.5" font-weight="600" fill="#374151">seq</text>
+<polygon points="330,286 350,300 330,314 310,300" fill="#fff" stroke="#374151" stroke-width="1.5"/>
+<text x="330" y="304" text-anchor="middle" font-size="10.5" font-weight="600" fill="#374151">if</text>
+<rect x="435" y="385" width="40" height="20" rx="5" fill="#fff" stroke="#374151" stroke-width="1.5"/>
+<text x="455" y="399" text-anchor="middle" font-size="10.5" font-weight="600" fill="#374151">seq</text>
+<rect x="310" y="385" width="40" height="20" rx="5" fill="#fff" stroke="#374151" stroke-width="1.5"/>
+<text x="330" y="399" text-anchor="middle" font-size="10.5" font-weight="600" fill="#374151">each</text>
+<rect x="580" y="66.0" width="150" height="28" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1.5"/>
+<text x="655.0" y="84" text-anchor="middle" font-size="12" fill="#111827">parse &amp; validate</text>
+<text x="742" y="84" font-size="11" fill="#16a34a">pure computation</text>
+<rect x="580" y="108.0" width="150" height="28" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+<text x="655.0" y="126" text-anchor="middle" font-size="12" fill="#111827">load catalog</text>
+<text x="742" y="126" font-size="11" fill="#2563eb">database</text>
+<rect x="580" y="150.0" width="150" height="28" rx="4" fill="#ffedd5" stroke="#ea580c" stroke-width="1.5"/>
+<text x="655.0" y="168" text-anchor="middle" font-size="12" fill="#111827">load stock levels</text>
+<text x="742" y="168" font-size="11" fill="#ea580c">HTTP service</text>
+<rect x="580" y="192.0" width="150" height="28" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1.5"/>
+<text x="655.0" y="210" text-anchor="middle" font-size="12" fill="#111827">compute availability</text>
+<text x="742" y="210" font-size="11" fill="#16a34a">pure computation</text>
+<rect x="580" y="234.0" width="150" height="28" rx="4" fill="#ffedd5" stroke="#ea580c" stroke-width="1.5"/>
+<text x="655.0" y="252" text-anchor="middle" font-size="12" fill="#111827">fetch promo</text>
+<text x="742" y="252" font-size="11" fill="#ea580c">HTTP service</text>
+<rect x="580" y="276.0" width="150" height="28" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1.5"/>
+<text x="655.0" y="294" text-anchor="middle" font-size="12" fill="#111827">apply promo</text>
+<text x="742" y="294" font-size="11" fill="#16a34a">pure computation</text>
+<rect x="580" y="318.0" width="150" height="28" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-width="1.5"/>
+<text x="655.0" y="336" text-anchor="middle" font-size="12" fill="#111827">standard pricing</text>
+<text x="742" y="336" font-size="11" fill="#16a34a">pure computation</text>
+<rect x="580" y="360.0" width="150" height="28" rx="4" fill="#ffedd5" stroke="#ea580c" stroke-width="1.5"/>
+<text x="655.0" y="378" text-anchor="middle" font-size="12" fill="#111827">reserve line item</text>
+<text x="742" y="378" font-size="11" fill="#ea580c">HTTP service</text>
+<rect x="580" y="402.0" width="150" height="28" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+<text x="655.0" y="420" text-anchor="middle" font-size="12" fill="#111827">record reservation</text>
+<text x="742" y="420" font-size="11" fill="#2563eb">database</text>
+<rect x="580" y="444.0" width="150" height="28" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+<text x="655.0" y="462" text-anchor="middle" font-size="12" fill="#111827">insert order</text>
+<text x="742" y="462" font-size="11" fill="#2563eb">database</text>
+<rect x="580" y="486.0" width="150" height="28" rx="4" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.5"/>
+<text x="655.0" y="504" text-anchor="middle" font-size="12" fill="#111827">publish OrderPlaced</text>
+<text x="742" y="504" font-size="11" fill="#7c3aed">message bus</text>
+</svg>

--- a/book-pfd-meta/REGENERATION-PREDICTIONS.md
+++ b/book-pfd-meta/REGENERATION-PREDICTIONS.md
@@ -1,0 +1,75 @@
+# Pre-registered predictions — the regeneration test
+
+**Registered 2026-09-05, BEFORE any builder was launched and before any comparison was made.**
+Owner's instruction: run it. Owner's design constraint, which shapes everything below: *the input is a
+PFD process and it is identical in all arms.*
+
+## The question this run exists to answer
+
+The postponed structure article's thesis is **path-independence**: that a JBCT codebase's structure is a
+function of its current requirements, not of the history by which it reached them. Debt, on that thesis, is a
+flow rather than a stock — it appears when requirements change and drains when the structure is brought back
+to them.
+
+Nothing measured so far speaks to it. Run 1 was contaminated. Run 1b's instrument was wrong. **Run 1c held the
+input identical across ten builders and measured convergence — every builder built from scratch, so no path
+varied.** The residue count run today (zero hand-written Reaction constructs in 5,009 lines) describes the
+present state of compliant code and says nothing about how it got there. Path-independence needs two *paths*
+to one set of requirements, and this run supplies them.
+
+## The two arms
+
+| Arm | Path | Input |
+|---|---|---|
+| **A — evolved** | built once, then maintained through 5 commits including a domain-model change | the process spec |
+| **B — fresh** | built once, from scratch, by a builder with no access to A | the same process spec |
+
+**Subject: B3 "Buy ticket"** from `docs/spec/02-processes-booking.md` in `ticketing`. Chosen because it is
+the only use case whose history contains a genuine model change rather than formatting: `5b685a4` — *"seat is
+the reservation identity, unblocking resale and hold-to-purchase"* — surrounded by a reformat, a suppression
+cleanup and a cause-grouping refactor. It is also the richest process in the spec: a compensating saga with a
+three-way concurrent gate, a binding write order, and a per-stage compensation table.
+
+**Input pinned:** `02-processes-booking.md`, sha256 `617d32cd3e3c570eba9760d393a3dc2468896e8375114a7f7e5a1ee70aaaa4b6`, 237 lines.
+**Arm A pinned:** `ticketing` at `0c61d81`.
+Note for the record: the spec is **untracked** in `ticketing`, so the sha256 above is the only pin that exists.
+
+## Isolation protocol
+
+Arm B's builder receives: the process spec, the JBCT book or skill, and the Pragmatica Core API reference.
+It does **not** receive: the `ticketing` repository, its git history, or any description of arm A's shape.
+This is the boundary Run 1 failed to hold; Run 1b established that it must be enforced rather than requested.
+
+## The metric, defined before looking
+
+Compared on the Run 1c instrument (data-dependency graph), plus the structural facts JBCT claims are
+determined:
+
+1. **Concurrency structure** — which steps are independent and therefore composed as Fork-Join.
+2. **Step count and boundaries** — how the process is cut into steps.
+3. **Write ordering** — the sequence of the three writes.
+4. **Return types per step** and the typed-error catalogue.
+5. **Placement** — package path under the telescope rule.
+
+## Predictions
+
+- **P1.** Arm B composes the three gate checks concurrently, as arm A does. *Falsified if B serialises them.*
+- **P2.** Arm B's step count is within ±1 of arm A's.
+- **P3.** Arm B preserves the binding write order (ticket, payment, booking last).
+- **P4 — the path-independence prediction, and the one that matters.** **No structural element of arm A is
+  attributable only to its history.** Concretely: nothing present in A and absent from B traces to the
+  superseded pre-`5b685a4` model in which the seat was not the reservation identity.
+  *Falsified if such an element exists* — that would be structural residue, i.e. debt as a stock.
+
+**Publication commitment, as in every prior run: the result is reported whichever way it falls, and P4's
+falsification is the headline if it triggers.**
+
+## What this run cannot license, stated in advance
+
+- **n = 1 use case, 1 builder.** It cannot estimate a rate; it can only fail to falsify, or falsify.
+- **The spec numbers its steps in execution order.** Run 1c disclosed the same limitation and it bit there,
+  because ordering was the thing under test. Here both arms read the same numbered spec, so ordering is
+  *given to both* rather than derived by either — the run is about the path, not about discovery.
+- **Requirements did not change between the arms.** A stronger test would evolve the requirements and
+  re-derive; this one asks the narrower question of whether maintenance leaves residue.
+- A match supports path-independence **on this instance**; it does not establish it as a property.

--- a/book-pfd-meta/REGENERATION-RESULTS.md
+++ b/book-pfd-meta/REGENERATION-RESULTS.md
@@ -68,7 +68,27 @@ difference, not a path difference.
 placed it at `...booking.usecase.buyticket`, dropping the workflow level and inserting a literal `usecase`
 segment.
 
-**CORRECTED 2026-09-06, on the owner's challenge.** This file first called that "a genuine miss ... neither
+**CORRECTED TWICE, 2026-09-06. The second correction reverses the first, and both reversals are recorded
+because the sequence is the finding.**
+
+**Correction 2 (final): arm B applied the rule correctly, and its placement is what the book prescribes for
+what it was asked to build.** The telescope rule in `book/project-structure.md` is explicit that structure
+*appears* with growth: *"A new app is flat. Every use case is a package directly under `usecase`"*, and its
+worked example shows `searchevents/  # still flat - in no workflow yet`. A workflow package appears only
+*"when several use cases cohere under one change driver"*. **Arm B built exactly one use case.** With no
+siblings, no workflow has appeared, so the use case belongs flat under `usecase` — which is precisely
+`...booking.usecase.buyticket`. Arm B kept the subsystem because the specification names three authoritative
+subsystems, and omitted the workflow because on its input there is none to name.
+
+Arm A carries `purchase` because arm A has the siblings — acquire hold, cancel ticket, sweep holds — that
+cohere into it. **So the placement difference is derived from the scope difference, exactly as the method
+says structure should be.** It is not indeterminacy and it is not an error. It is the rule working.
+
+**Consequence for the run: after this correction there is no divergence attributable to the method, and none
+attributable to a mistake.** All three trace to inputs arm B did not have — the routing mechanism, the
+sibling use cases, and the scope. The run's structural agreement is therefore stronger than first scored.
+
+**Correction 1 (superseded, kept for the record).** This file first called that "a genuine miss ... neither
 an outside constraint nor the history explains it", and framed it as the boundary of the determinism claim.
 That framing was wrong, and the correction matters more than the original reading.
 
@@ -80,8 +100,21 @@ and still producing the wrong path has *misapplied a determinate rule*. That is 
 the method permits a choice. A determinate method can be misapplied; the two are different claims and this
 file conflated them.
 
-**What the divergence does evidence is a gap in the enforcer, and it is worth more than the original
-reading.** No lint rule checks telescope placement. The ARCH family covers dependency direction
+**What survives from correction 1 — and the owner sharpened it further.** No lint rule checks telescope
+placement, and **it cannot**: the package path is the only record in the codebase of which use cases cohere
+under which change driver. A checker compares two things, and here there is only one. Placement encodes
+business context for which the code holds no second source of truth, so this is not a gap the toolchain can
+close — it is outside the checkable fraction by construction. The only place both sides exist is authoring
+time, where the specification and the code are in hand together, which makes it a skill obligation rather
+than a gate rule.
+
+Recorded as a real gap regardless: the JBCT skill does **not** carry the telescope rule at all — zero hits
+for it across `ai-tools/skills/jbct/`, and `sync-book-blocks.py` syncs import ordering and member ordering
+from `book/project-structure.md` while leaving *The Telescope Rule* unsynced. Arm B reached the right
+placement without ever being given the rule. Note for decision 5's fidelity check: counting gate rejects
+would not have detected this, because the gate cannot see placement.
+
+For the record, the ARCH family in full: no rule in any of the 77 knows what package a use case belongs in. The ARCH family covers dependency direction
 (`JBCT-ARCH-01`), the lift zone (`-02`), use-case coupling (`-03`) and slice internals (`-04`); no rule in
 any of the 77 knows what package a use case belongs in. So the one structural error in the run is precisely
 the class `jbct check` cannot see — which is why it survived into an artifact that passes the gate with 0

--- a/book-pfd-meta/REGENERATION-RESULTS.md
+++ b/book-pfd-meta/REGENERATION-RESULTS.md
@@ -63,11 +63,29 @@ shared `BookingStore` port of seven methods plus cross-slice use case calls. Arm
 several sharing that store; arm B built one use case alone and had nothing to share with. Again an input
 difference, not a path difference.
 
-**3. Placement — a genuine miss, and arm B's.** Arm A places the use case at
+**3. Placement — a misclassification by arm B, not an indeterminacy.** Arm A places the use case at
 `...booking.purchase.buyticket`: subsystem, **workflow**, use case, as the telescope rule requires. Arm B
 placed it at `...booking.usecase.buyticket`, dropping the workflow level and inserting a literal `usecase`
-segment. The specification describes the workflow; arm B did not derive the level from it. This is the one
-place where the two structures differ and neither an outside constraint nor the history explains it.
+segment.
+
+**CORRECTED 2026-09-06, on the owner's challenge.** This file first called that "a genuine miss ... neither
+an outside constraint nor the history explains it", and framed it as the boundary of the determinism claim.
+That framing was wrong, and the correction matters more than the original reading.
+
+Both inputs the derivation needs were present. **The workflow is named in the specification**: the README's
+index says `02-processes-booking.md` contains "Holds, **purchase**, cancellation, hold expiry", and B3 *Buy
+ticket* is the purchase process — `purchase` is exactly the segment arm A used. **The rule was also
+present**: the telescope is JBCT's, and arm B had the skill. An applier holding both the fact and the rule
+and still producing the wrong path has *misapplied a determinate rule*. That is an error, not evidence that
+the method permits a choice. A determinate method can be misapplied; the two are different claims and this
+file conflated them.
+
+**What the divergence does evidence is a gap in the enforcer, and it is worth more than the original
+reading.** No lint rule checks telescope placement. The ARCH family covers dependency direction
+(`JBCT-ARCH-01`), the lift zone (`-02`), use-case coupling (`-03`) and slice internals (`-04`); no rule in
+any of the 77 knows what package a use case belongs in. So the one structural error in the run is precisely
+the class `jbct check` cannot see — which is why it survived into an artifact that passes the gate with 0
+errors. The telescope is prescribed in the book and unenforced in the toolchain.
 
 ## What this licenses, and what it does not
 
@@ -77,6 +95,8 @@ complete failure catalogue, and — the point of the run — the structure intro
 without access to that change. Path-independence is **supported on this instance**.
 
 **Not licensed.** n = 1 use case and n = 1 builder; this can falsify, it cannot estimate a rate.
+Note that after the placement correction above, **the run contains no divergence attributable to the method
+itself**: two trace to inputs arm B lacked, and the third to an applier error the gate does not catch.
 Requirements did not change *between* the arms, so the run asks whether maintenance leaves residue, not
 whether a re-derivation after changed requirements converges. The specification numbers its steps in
 execution order, which was disclosed in advance and matters less here than in Run 1c because both arms read

--- a/book-pfd-meta/REGENERATION-RESULTS.md
+++ b/book-pfd-meta/REGENERATION-RESULTS.md
@@ -1,0 +1,89 @@
+# The regeneration test — results
+
+Registered in `REGENERATION-PREDICTIONS.md` at `d07f42d`, **before any builder was launched**. Arm A's
+structure was extracted and written down **before arm B reported**. Scored 2026-09-05.
+
+# Headline: P1, P2, P3 hit. P4 is not falsified, and the structure the model change produced regenerates from the current specification alone.
+
+## Isolation held
+
+Arm B's builder disclosed its sources unprompted: the eleven spec files, the JBCT skill, and Pragmatica
+Core's `lang` package. It ran `jbct lint` against Core's own `vo` package as an instrument check. It read
+nothing under `ticketing` and ran no search across `~/IdeaProjects`. Run 1's failure mode did not recur.
+
+Arm B's artifact is real, not a sketch: 16 files, 973 lines, compiling under `javac -Xlint:all` against
+`core-1.0.0-rc4.jar` with no warnings, a 26-check behavioural harness passing, and `jbct lint` reporting
+0 errors and 24 warnings. Its author mutation-probed its own harness twice — writing the booking row first
+turns the ordering check red, and dropping compensation turns five checks red — so the harness can fail.
+
+## Scoring
+
+| Prediction | Arm A (evolved) | Arm B (fresh) | Verdict |
+|---|---|---|---|
+| **P1** three gate checks concurrent | `Promise.all(readSaleStatus, countActiveBookings, readSeatSellability)` | `Promise.all(gateSale, gateSeat, gateCustomer)` | **HIT** |
+| **P2** step count within ±1 | 5 stage records | 4 stage records | **HIT** |
+| **P3** write order preserved | insertTicket → insertPayment → insertBooking | saveTicket → savePayment → saveBooking | **HIT** |
+| **P4** nothing traces only to history | — | — | **NOT FALSIFIED** (below) |
+
+Neither arm was told to parallelise validation, and both did: `Result.all` over the four field parses,
+independently, in addition to the gate.
+
+## P4 in detail — the prediction the run existed for
+
+The model change under test is `5b685a4`, *"seat is the reservation identity, unblocking resale and
+hold-to-purchase"*. Before it, the reservation was not keyed by seat. The candidate residue surfaces were
+named in advance: `ReservedBuy.claimId`, the `confirmReservation` keying, and the `claimSeat` guarded claim.
+
+**Arm B produced all three, from the current specification, with no access to that history.** It declares
+`ClaimId` as a value type, wins it in `ClaimSeat`, carries it in a `Claimed` stage record, and keys
+`ConfirmClaim` and `ReleaseClaim` by it. That is arm A's post-change shape, regenerated.
+
+So the structure the model change produced is a function of the requirements as they now stand, not a
+trace of the change that introduced it. On this instance, **debt did not accumulate as a stock: the
+evolved code is what a fresh build produces.**
+
+## The three divergences, reported because they are the interesting part
+
+**1. Error grouping — and arm A's own comment names arm B's answer.** Both arms produced *the same ten
+failure values*, including two records with identical names and identical two-field shapes
+(`InvalidRequest`, `UnacceptableValue`). Arm A splits the eight fixed-message causes into four enums by
+HTTP status; arm B puts all eight into one enum named **`General`**. Arm A's javadoc explains why it does
+not: *"which is why the group is named for that routing rule rather than `General`"* — route error-mapping
+targets a whole status class by the enum's simple name, via `routes.toml`.
+
+Arm B **had the status mapping** (`08-failure-catalog.md` carries a Status column; `07-http-api.md` lists
+400, 402, 409, 422, 503 for this endpoint) and still did not group by it. What arm B did not have is the
+*mechanism that makes the grouping pay* — `routes.toml` pattern-matching on an enum's simple name is an
+Aether deployment artifact, absent from the process specification. The divergence is a response to a
+constraint outside the input, not residue from arm A's path. Arm A reached this form in `7122341`, a
+refactor **after** the model change.
+
+**2. Dependency granularity.** Arm B declared fourteen single-method step interfaces. Arm A uses one
+shared `BookingStore` port of seven methods plus cross-slice use case calls. Arm A is one use case among
+several sharing that store; arm B built one use case alone and had nothing to share with. Again an input
+difference, not a path difference.
+
+**3. Placement — a genuine miss, and arm B's.** Arm A places the use case at
+`...booking.purchase.buyticket`: subsystem, **workflow**, use case, as the telescope rule requires. Arm B
+placed it at `...booking.usecase.buyticket`, dropping the workflow level and inserting a literal `usecase`
+segment. The specification describes the workflow; arm B did not derive the level from it. This is the one
+place where the two structures differ and neither an outside constraint nor the history explains it.
+
+## What this licenses, and what it does not
+
+**Licensed.** On this use case, a fresh build from the current process specification reproduces the
+evolved code's concurrency structure, its write ordering, its stage decomposition within one record, its
+complete failure catalogue, and — the point of the run — the structure introduced by a domain-model change,
+without access to that change. Path-independence is **supported on this instance**.
+
+**Not licensed.** n = 1 use case and n = 1 builder; this can falsify, it cannot estimate a rate.
+Requirements did not change *between* the arms, so the run asks whether maintenance leaves residue, not
+whether a re-derivation after changed requirements converges. The specification numbers its steps in
+execution order, which was disclosed in advance and matters less here than in Run 1c because both arms read
+the same numbering. And the two structures were compared by one reader — me — who wrote arm A's description
+before seeing arm B's, but who is not blind to the thesis.
+
+**The honest caveat the run itself produced:** two of the three divergences trace to inputs arm A had and
+arm B did not. "The input is the PFD process" is the design's assumption, and arm A was in fact also shaped
+by a routing configuration and by sibling use cases. A stronger successor gives both arms the whole input,
+or states the boundary of "the process" more narrowly than a repository does.


### PR DESCRIPTION
Three artifacts for the postponed JBCT structure/debt article, whose evidence gaps the owner asked to close.

**The illustration** existed in no commit on any branch and the working tree held the only copy on disk.

**The regeneration test**, pre-registered at `d07f42d` before any builder was launched, scored at `aeaaa4d`. Arm A's structure was written down before arm B reported. Subject: the buy-ticket use case, chosen because its history contains a genuine domain-model change (`5b685a4`, seat becomes the reservation identity) rather than formatting.

Result: P1, P2 and P3 hit — the three-way gate is a fork-join in both arms, the binding write order is preserved in both, and the stage decompositions differ by one record. **P4 is not falsified**: the structure the model change introduced regenerates from the current specification alone, in a build with no access to that history.

Three divergences are reported rather than buried. Two trace to inputs the evolved code had and the fresh build did not (route mapping, sibling use cases). The third is a genuine miss by the fresh build: it did not derive the workflow level of the telescope.

Isolation held — the builder disclosed its sources unprompted and read nothing from the application. Its artifact compiles clean against the released core with a 26-check harness and two mutation probes proving the harness can fail.