### PR TITLE
docs: handover 2026-09-06

### DIFF
--- a/HANDOVER-2026-09-06.md
+++ b/HANDOVER-2026-09-06.md
@@ -1,0 +1,128 @@
+# Handover — 2026-09-06 (session: pfd-editor)
+
+Continues `HANDOVER-2026-09-02.md`. **23 commits, six PRs merged, `main` pushed and clean, all four
+checkers green.** The private pair in `../oss/internal/` carries the conference records.
+
+Versions unchanged and unpublished: JBCT **5.0.0**, PFD **3.0.0**, AS **1.1.2**, Aether 0.1.0 draft.
+Three books now carry `[Unreleased]` changelog entries. **They are PATCH releases** (5.0.1 / 3.0.1 /
+1.1.3), by owner ruling — see below.
+
+---
+
+## Read this first: three things that will bite a successor
+
+**1. An outside reviewer found eight defects and seven were real.** A different AI model, at the owner's
+direction, audited the site cold and produced findings that our own agents had not. Everything it reported
+was verified at source before acting, and that mattered: two of eight claims were confident paraphrases of
+our own text rather than quotes. **Its output is claims to verify, never findings.** Full record in
+`../oss/internal/roadmap-conference-2026-09-04.md`.
+
+**2. I asserted three things today that were inference dressed as fact, and peers caught two of them.**
+The provenance of that review ("external review", written into four changelogs and a public page before
+anyone knew who wrote it), a stale Medium copy that does not exist, and a core-library hole that was an
+Aether-module fix. The standing rule is now in memory: check state outside this repository before writing
+it down, or write the weaker sentence that is true without the check.
+
+**3. Corrections are recorded, not silently applied.** Two entries in `REGENERATION-RESULTS.md` reverse
+earlier readings in that same file, on purpose. Do not tidy them away; the sequence is the finding.
+
+---
+
+## What shipped
+
+| | |
+|---|---|
+| **Site review corrections** | eight defects fixed in source and live (PR #62): the coverage contradiction across both testing chapters, "exactly four return types", the measurable-criteria overclaim, PFD's falsified "selection is not a procedure", the homepage evidence claim, the stale `/method/` hub, ownership-vs-contention, quasi-linear scope |
+| **Article claim corrections** | `fail-safe-legacy` availability sentence and the Aether article's upgrade claim, both rewritten under the lens on site + dev.to (PRs #59, #65); canonicals repaired |
+| **Roadmap conference** | inventory + position + adversary brief + eight landed decisions; my domain's items listed under Open |
+| **Regeneration test** | pre-registered, run, scored, corrected twice (PR #66) |
+| **Telescope rule into the skill** | plus link rewriting in `sync-book-blocks.py` (PR #66) |
+| **Versioning rule** | "correcting a defect is a PATCH" recorded in `BOOK-VERSIONING.md` (PR #63) |
+| **New article draft** | `articles/beyond-functions-anatomy.md`, 1,789 words, `published: false`, uncommitted |
+
+---
+
+## Owner rulings — do not reopen
+
+1. **These corrections are PATCH releases, not majors.** `BOOK-VERSIONING.md` now carries the
+   disambiguation and PFD's own 2.4.2 precedent. I had read that citation backwards.
+2. **Medium stays.** The conference proposed dropping it; the owner rejected on traction data none of us
+   had, including recent organic subscriber growth. dev.to demoted to syndication, not dropped.
+3. **Silence on prior art in the new article.** Jackson Structured Programming, Mills' prime decomposition
+   and Haxl's applicative concurrency are all genuine ancestors and none is cited. **Silence is safe; a
+   novelty sentence is not** — one claim of being first would be refuted by any reader who knows JSP.
+4. **The new article's register: observations, not proofs.** Measurements exist and stay available if a
+   sentence needs grounding, but the piece shows what you notice, not what was measured.
+5. **The properties are properties of JBCT-style code**, not of request handling in general. This was a
+   late correction to the draft and it improved it; do not let the framing slip back.
+
+---
+
+## The regeneration test, because its result is load-bearing
+
+`book-pfd-meta/REGENERATION-PREDICTIONS.md` (registered before any builder launched) and
+`-RESULTS.md`. Subject: buy-ticket, the one use case whose history holds a real model change
+(`5b685a4`, seat becomes the reservation identity). Arm A evolved, arm B built fresh from the same
+spec in isolation.
+
+**P1-P3 hit; P4 not falsified.** The structure the model change introduced regenerates from the current
+specification with no access to that history. After two recorded corrections, **no divergence is
+attributable to the method or to an error** — all three trace to inputs arm B lacked.
+
+**Do not cite the run without this sentence:** arm B ran against a skill that did not contain the telescope
+rule, and the skill now does. The result measures the toolchain as it was that evening.
+
+---
+
+## Traps
+
+- **The classifier blocks `gh pr merge --admin` from this session**, as it does for the CTO. The owner runs
+  merge lines with `!`. It permitted one merge late in the session; do not rely on that.
+- **A zero is what a broken grep returns.** The Reaction count was validated by running the same pattern
+  against code that must contain those constructs (8-11 per 1,000 lines) before the zero was believed.
+- **The Medium stats table's columns are Presentations / Views / Reads**, not Views / Reads. Every ratio
+  derived from the wrong alignment was a feed clickthrough rate. Check the dashboard labels before
+  computing anything.
+- **`jbct lint` cannot check placement, and no rule should be written for it.** The package path is the
+  only record of which use cases cohere under which change driver, so a checker has one side of the
+  comparison and not two. It is an authoring-time obligation, now in the skill.
+- **The analytics snippet greps as `/p/pl.js`, not `pirsch`.** Searching for the vendor name finds nothing
+  and looks like the install is missing.
+
+---
+
+## Open
+
+**Mine, uncommitted in the tree:**
+- `articles/beyond-functions-anatomy.md` — the draft, unreviewed by the owner.
+- `.github/DISCUSSION_TEMPLATE/audits.yml` and `ai-tools/count-audits.sh` — decision 4's intake. **The
+  category must be created in repo settings with the slug `audits`** or the form will not attach.
+- `book/appendix-c-glossary.md` — the Leaf correction from the postponed article work, pending since 09-02.
+
+**Mine, from the conference:**
+- Decision 5's fidelity check: run the books' examples through the skill and count gate rejects. Note it
+  **cannot** catch placement drift, so its scope needs stating.
+- Routing to the Audits intake from the counterexamples page, every course's last lesson, the AS "Monday"
+  section and the JBCT toolchain page. **Links go live only when R1/R2 are green.**
+- Issues #60 (one derived version declaration) and #61 (retire the legacy tooling pages).
+
+**Owed elsewhere:** the Medium copy of the Aether article still carries the old upgrade claim; the API is
+create-only so it needs a manual edit. Owner deferred it until after the conference. Memory:
+`project-medium-correction-owed`.
+
+**Staged, not decided:** UTM tagging. Verified that Pirsch captures all five parameters, that our worker
+does not strip query strings, and that events attach to sessions. **Precondition: nobody has ever watched
+the outbound-to-Leanpub event fire** — open since 08-27, and the whole reason Pirsch was chosen.
+
+---
+
+## Working notes
+
+- **Verify a peer before relaying, and verify yourself before publishing.** Every relayed fact that reached
+  a book, a changelog or an article this session was checked at source first. The two that were not are
+  the two that had to be corrected.
+- **Count before proposing.** A mechanism proposed for article command-sequence drift was withdrawn by its
+  author after the count came back as one shell block in 27 articles. That saved an owner turn.
+- **A decision record is a standing claim.** The conference staged a document whose bullets contradicted
+  amendments twenty lines below them, on the same day three sessions spent hours removing exactly that from
+  books and articles. Read your own records the way you read the product's.


### PR DESCRIPTION
Session handover. 23 commits and six PRs since the last one.

Covers: the outside review and its eight findings, the roadmap conference and the decisions that fall to this repo, the regeneration test with both of its recorded corrections, the telescope rule reaching the skill, and the new article draft.

Three things a successor needs early: the reviewer's output is claims to verify rather than findings; three assertions this session were inference dressed as fact and peers caught two; and the corrections inside the regeneration results are deliberate, not clutter.